### PR TITLE
Enhance linting setup and add basic `README` and `CONTRIBUTING` files

### DIFF
--- a/.editorconfig
+++ b/.editorconfig
@@ -1,0 +1,18 @@
+# This file is for unifying the coding style for different editors and IDEs
+# editorconfig.org
+
+# WordPress Coding Standards
+# https://make.wordpress.org/core/handbook/coding-standards/
+
+root = true
+
+[*]
+charset = utf-8
+end_of_line = lf
+insert_final_newline = true
+trim_trailing_whitespace = true
+indent_style = tab
+
+[*.{yml,yaml}]
+indent_style = space
+indent_size = 2

--- a/.github/workflows/php-lint.yml
+++ b/.github/workflows/php-lint.yml
@@ -1,0 +1,59 @@
+name: PHP Code Linting
+
+on:
+  push:
+    branches:
+      - trunk
+      - 'feature/**'
+      - 'release/**'
+    # Only run if PHP-related files changed.
+    paths:
+      - '.github/workflows/php-lint.yml'
+      - '**.php'
+      - 'phpcs.xml.dist'
+      - 'phpstan.neon.dist'
+      - 'composer.json'
+      - 'composer.lock'
+  pull_request:
+    # Only run if PHP-related files changed.
+    paths:
+      - '.github/workflows/php-lint.yml'
+      - '**.php'
+      - 'phpcs.xml.dist'
+      - 'phpstan.neon.dist'
+      - 'composer.json'
+      - 'composer.lock'
+    types:
+      - opened
+      - reopened
+      - synchronize
+
+concurrency:
+  group: ${{ github.workflow }}-${{ github.ref }}
+  cancel-in-progress: ${{ github.ref != 'refs/heads/main' }}
+
+jobs:
+  php-lint:
+    name: PHP
+    runs-on: ubuntu-latest
+    timeout-minutes: 20
+    steps:
+      - uses: actions/checkout@v4
+
+      - uses: shivammathur/setup-php@v2
+        with:
+          php-version: 'latest'
+
+      - name: Validate Composer configuration
+        run: composer validate
+
+      - name: Install PHP dependencies
+        uses: ramsey/composer-install@v3
+        with:
+          composer-options: '--prefer-dist'
+
+      - name: PHPStan
+        run: composer phpstan
+
+      - name: PHP Code Sniffer
+        run: composer phpcs

--- a/CONTRIBUTING.md
+++ b/CONTRIBUTING.md
@@ -47,8 +47,8 @@ All code must be properly documented with PHPDoc blocks following these standard
  *
  * @since n.e.x.t
  */
-class Auth_Handler
-{
+class Auth_Handler {
+
     /**
      * Validates user credentials against the database.
      *

--- a/CONTRIBUTING.md
+++ b/CONTRIBUTING.md
@@ -1,0 +1,94 @@
+# Contributing to the WordPress AI Client package
+
+Thank you for your interest in contributing to the WordPress AI Client package! Here you find some information on how to get started. As this repository is in its very early stages, expect more detailed instructions to come soon.
+
+## Coding standards
+
+All code in this project must follow the [WordPress Coding Standards](https://developer.wordpress.org/coding-standards/wordpress-coding-standards/). Since it is a Composer package, there are a few exceptions to this, most importantly the file names which should match the respective class, to facilitate PSR-4 autoloading. But other than that the code must adhere to the WordPress Coding Standards.
+
+All parameters, return values, and properties must use explicit type hints, except in cases where providing the correct type hint would be impossible given limitations of the oldest supported PHP version (see below).
+
+## Naming conventions
+
+The following naming conventions must be followed for consistency and autoloading:
+
+- Interfaces are suffixed with `_Interface`.
+- Traits are suffixed with `_Trait`.
+- Enums are suffixed with `_Enum`.
+- File names are the same as the class, trait, and interface name for PSR-4 autoloading.
+- Classes, interfaces, and traits, and namespaces are not prefixed with `AI_`, excluding the root namespace.
+
+## Documentation standards
+
+All code must be properly documented with PHPDoc blocks following these standards:
+
+### General rules
+
+- All descriptions must end with a period.
+- Use `@since n.e.x.t` for new code (will be replaced with actual version on release).
+- Place `@since` tags below the description and above `@param` tags, with blank comment lines around it.
+
+### Method documentation
+
+- Method descriptions must start with a third-person verb (e.g., "Creates", "Returns", "Checks").
+- Exceptions: Constructors and magic methods may use different phrasing.
+- All `@return` annotations must include a description.
+
+### Interface implementations
+
+- Use `{@inheritDoc}` instead of duplicating descriptions when implementing interface methods.
+- Only provide a unique description if it adds value beyond the interface documentation.
+
+### Example
+
+```php
+/**
+ * Class for handling user authentication requests.
+ *
+ * @since n.e.x.t
+ */
+class Auth_Handler
+{
+    /**
+     * Validates user credentials against the database.
+     *
+     * @since n.e.x.t
+     * 
+     * @param string $username The username to validate.
+     * @param string $password The password to validate.
+     * @return bool True if credentials are valid, false otherwise.
+     */
+    public function validate( string $username, string $password ): bool {
+        // Implementation
+    }
+}
+```
+
+### Array Lists
+
+When an array is a list — that is, an array where the keys are sequential, starting at 0 — use the `list` generic type within the docblock. For example, a parameter that is a list of strings would be documented as `@param list<string> $variable`.
+
+Note that `list<string>` and `string[]` _are not_ the same. The latter is an alias for `array<int, string>` which does not enforce that the keys are sequential. That particular syntax, therefore, will rarely be used.
+
+## PHP Compatibility
+
+All code must be backward compatible with PHP 7.4, which is the minimum required PHP version for this project.
+
+## Branch naming conventions
+
+There are a few protected branch naming conventions:
+
+* `trunk`: The main development branch.
+* `release/*`: A branch for a specific release, useful e.g. for applying a hotfix.
+* `feature/*`: A branch for a larger feature that takes multiple iterative PRs towards completion.
+
+These special branches are protected and are configured more strictly in regards to GitHub workflow configuration.
+
+Branches that you use for implementing a pull request or experimenting can use any naming convention you prefer, _except_ the above. Additionally, please do not use branch names that would easily cause confusion, such as other common main branch names like `main` or `develop`.
+
+Ideally, the branch name is in some form or shape descriptive of what it is for.
+
+## Guidelines
+
+- As with all WordPress projects, we want to ensure a welcoming environment for everyone. With that in mind, all contributors are expected to follow our [Code of Conduct](https://make.wordpress.org/handbook/community-code-of-conduct/).
+- All WordPress projects are [licensed under the GPLv2+](/LICENSE.md), and all contributions to the WordPress AI Client package will be released under the GPLv2+ license. You maintain copyright over any contribution you make, and by submitting a pull request, you are agreeing to release that contribution under the GPLv2+ license.

--- a/README.md
+++ b/README.md
@@ -1,0 +1,19 @@
+# WordPress AI Client
+
+[_Part of the **AI Building Blocks for WordPress** initiative_](https://make.wordpress.org/ai/2025/07/17/ai-building-blocks)
+
+An AI client and API for WordPress to communicate with any generative AI models of various capabilities using a uniform API.
+
+Built on top of the [PHP AI Client](https://github.com/WordPress/php-ai-client).
+
+**Work in progress:** This project is in its early development stages and not usable yet.
+
+## Installation
+
+```
+composer require wordpress/wp-ai-client
+```
+
+## Further reading
+
+See the [contributing documentation](./CONTRIBUTING.md) for more information on how to get involved.

--- a/composer.json
+++ b/composer.json
@@ -21,9 +21,9 @@
         "source": "https://github.com/WordPress/wp-ai-client"
     },
     "autoload": {
-        "files": [
-            "includes/bootstrap.php"
-        ]
+        "psr-4": {
+            "Wordpress\\AI_Client\\": "includes/"
+        }
     },
     "minimum-stability": "dev",
     "prefer-stable": true,

--- a/composer.json
+++ b/composer.json
@@ -33,12 +33,13 @@
         "wordpress/php-ai-client": "^0.1"
     },
     "require-dev": {
-        "squizlabs/php_codesniffer": "^3.7",
-        "wp-coding-standards/wpcs": "^3.0",
-        "phpcompatibility/phpcompatibility-wp": "^2.1",
         "automattic/vipwpcs": "^3.0",
+        "dealerdirect/phpcodesniffer-composer-installer": "^1.0",
+        "phpcompatibility/phpcompatibility-wp": "^2.1",
+        "phpstan/phpstan": "~2.1",
         "slevomat/coding-standard": "^8.0",
-        "dealerdirect/phpcodesniffer-composer-installer": "^1.0"
+        "squizlabs/php_codesniffer": "^3.7",
+        "wp-coding-standards/wpcs": "^3.0"
     },
     "config": {
         "allow-plugins": {
@@ -51,7 +52,12 @@
         }
     },
     "scripts": {
+        "lint": [
+            "@phpcs",
+            "@phpstan"
+        ],
         "phpcs": "phpcs",
-        "phpcbf": "phpcbf"
+        "phpcbf": "phpcbf",
+        "phpstan": "phpstan analyze --memory-limit=256M"
     }
 }

--- a/composer.json
+++ b/composer.json
@@ -22,7 +22,7 @@
     },
     "autoload": {
         "psr-4": {
-            "Wordpress\\AI_Client\\": "includes/"
+            "WordPress\\AI_Client\\": "includes/"
         }
     },
     "minimum-stability": "dev",

--- a/composer.lock
+++ b/composer.lock
@@ -4,7 +4,7 @@
         "Read more about it at https://getcomposer.org/doc/01-basic-usage.md#installing-dependencies",
         "This file is @generated automatically"
     ],
-    "content-hash": "bd4796c4b09080fa7b17ac431b59d93a",
+    "content-hash": "7dbba8d15fdd8095bb14f9df989589e1",
     "packages": [
         {
             "name": "php-http/discovery",
@@ -1060,6 +1060,64 @@
             "time": "2025-08-30T15:50:23+00:00"
         },
         {
+            "name": "phpstan/phpstan",
+            "version": "2.1.22",
+            "source": {
+                "type": "git",
+                "url": "https://github.com/phpstan/phpstan.git",
+                "reference": "41600c8379eb5aee63e9413fe9e97273e25d57e4"
+            },
+            "dist": {
+                "type": "zip",
+                "url": "https://api.github.com/repos/phpstan/phpstan/zipball/41600c8379eb5aee63e9413fe9e97273e25d57e4",
+                "reference": "41600c8379eb5aee63e9413fe9e97273e25d57e4",
+                "shasum": ""
+            },
+            "require": {
+                "php": "^7.4|^8.0"
+            },
+            "conflict": {
+                "phpstan/phpstan-shim": "*"
+            },
+            "bin": [
+                "phpstan",
+                "phpstan.phar"
+            ],
+            "type": "library",
+            "autoload": {
+                "files": [
+                    "bootstrap.php"
+                ]
+            },
+            "notification-url": "https://packagist.org/downloads/",
+            "license": [
+                "MIT"
+            ],
+            "description": "PHPStan - PHP Static Analysis Tool",
+            "keywords": [
+                "dev",
+                "static analysis"
+            ],
+            "support": {
+                "docs": "https://phpstan.org/user-guide/getting-started",
+                "forum": "https://github.com/phpstan/phpstan/discussions",
+                "issues": "https://github.com/phpstan/phpstan/issues",
+                "security": "https://github.com/phpstan/phpstan/security/policy",
+                "source": "https://github.com/phpstan/phpstan-src"
+            },
+            "funding": [
+                {
+                    "url": "https://github.com/ondrejmirtes",
+                    "type": "github"
+                },
+                {
+                    "url": "https://github.com/phpstan",
+                    "type": "github"
+                }
+            ],
+            "time": "2025-08-04T19:17:37+00:00"
+        },
+        {
             "name": "sirbrillig/phpcs-variable-analysis",
             "version": "v2.12.0",
             "source": {
@@ -1118,32 +1176,32 @@
         },
         {
             "name": "slevomat/coding-standard",
-            "version": "8.20.0",
+            "version": "8.21.1",
             "source": {
                 "type": "git",
                 "url": "https://github.com/slevomat/coding-standard.git",
-                "reference": "b4f9f02edd4e6a586777f0cabe8d05574323f3eb"
+                "reference": "2b801e950ae1cceb30bb3c0373141f553c99d3c3"
             },
             "dist": {
                 "type": "zip",
-                "url": "https://api.github.com/repos/slevomat/coding-standard/zipball/b4f9f02edd4e6a586777f0cabe8d05574323f3eb",
-                "reference": "b4f9f02edd4e6a586777f0cabe8d05574323f3eb",
+                "url": "https://api.github.com/repos/slevomat/coding-standard/zipball/2b801e950ae1cceb30bb3c0373141f553c99d3c3",
+                "reference": "2b801e950ae1cceb30bb3c0373141f553c99d3c3",
                 "shasum": ""
             },
             "require": {
                 "dealerdirect/phpcodesniffer-composer-installer": "^0.6.2 || ^0.7 || ^1.1.2",
                 "php": "^7.4 || ^8.0",
-                "phpstan/phpdoc-parser": "^2.2.0",
+                "phpstan/phpdoc-parser": "^2.3.0",
                 "squizlabs/php_codesniffer": "^3.13.2"
             },
             "require-dev": {
                 "phing/phing": "3.0.1|3.1.0",
                 "php-parallel-lint/php-parallel-lint": "1.4.0",
-                "phpstan/phpstan": "2.1.19",
+                "phpstan/phpstan": "2.1.22",
                 "phpstan/phpstan-deprecation-rules": "2.0.3",
                 "phpstan/phpstan-phpunit": "2.0.7",
                 "phpstan/phpstan-strict-rules": "2.0.6",
-                "phpunit/phpunit": "9.6.8|10.5.48|11.4.4|11.5.27|12.2.7"
+                "phpunit/phpunit": "9.6.8|10.5.48|11.4.4|11.5.27|12.3.7"
             },
             "type": "phpcodesniffer-standard",
             "extra": {
@@ -1167,7 +1225,7 @@
             ],
             "support": {
                 "issues": "https://github.com/slevomat/coding-standard/issues",
-                "source": "https://github.com/slevomat/coding-standard/tree/8.20.0"
+                "source": "https://github.com/slevomat/coding-standard/tree/8.21.1"
             },
             "funding": [
                 {
@@ -1179,7 +1237,7 @@
                     "type": "tidelift"
                 }
             ],
-            "time": "2025-07-26T15:35:10+00:00"
+            "time": "2025-08-31T13:32:28+00:00"
         },
         {
             "name": "squizlabs/php_codesniffer",
@@ -1334,14 +1392,14 @@
     ],
     "aliases": [],
     "minimum-stability": "dev",
-    "stability-flags": {},
+    "stability-flags": [],
     "prefer-stable": true,
     "prefer-lowest": false,
     "platform": {
         "php": ">=7.4",
         "ext-json": "*"
     },
-    "platform-dev": {},
+    "platform-dev": [],
     "platform-overrides": {
         "php": "7.4"
     },

--- a/includes/Test_Class.php
+++ b/includes/Test_Class.php
@@ -1,0 +1,28 @@
+<?php
+/**
+ * Class WordPress\AI_Client\Test_Class
+ *
+ * @since n.e.x.t
+ * @package wp-ai-client
+ */
+
+namespace WordPress\AI_Client;
+
+/**
+ * Test class.
+ *
+ * @since n.e.x.t
+ */
+class Test_Class {
+
+	/**
+	 * Returns true.
+	 *
+	 * @since n.e.x.t
+	 *
+	 * @return bool Always true.
+	 */
+	public function return_true(): bool {
+		return true;
+	}
+}

--- a/phpcs.xml
+++ b/phpcs.xml
@@ -2,25 +2,27 @@
 <ruleset name="WordPress AI Client">
 	<description>WordPress Coding Standards for WordPress AI Client</description>
 
-	<!-- What to scan -->
-	<file>.</file>
-	<exclude-pattern>/vendor/</exclude-pattern>
-	<exclude-pattern>/node_modules/</exclude-pattern>
+    <!-- Scan these files -->
+    <file>includes</file>
+    <!-- Uncomment when we have tests. <file>tests</file>-->
 
-	<!-- How to scan -->
-	<arg value="sp"/> <!-- Show sniff and progress -->
-	<arg name="basepath" value="./"/><!-- Strip the file paths down to the relevant bit -->
-	<arg name="colors"/>
-	<arg name="extensions" value="php"/>
-	<arg name="parallel" value="8"/><!-- Enables parallel processing when available for faster results. -->
+    <!-- Ignore vendor directory -->
+    <exclude-pattern>*/vendor/*</exclude-pattern>
 
-	<!-- Rules: Check PHP version compatibility -->
-	<config name="testVersion" value="7.4-"/>
-	<rule ref="PHPCompatibilityWP"/>
+    <!-- Show progress, show sniff codes in all reports -->
+    <arg value="sp"/>
 
-	<!-- Rules: WordPress Coding Standards -->
+    <!-- Set minimum supported PHP version -->
+    <config name="testVersion" value="7.4-"/>
+
+    <!-- Enable colors in output -->
+    <arg name="colors"/>
+
+	<!-- WordPress Coding Standards -->
 	<config name="minimum_supported_wp_version" value="6.0"/>
-	<rule ref="WordPress"/>
+	<rule ref="WordPress">
+		<exclude name="WordPress.Files.FileName"/>
+	</rule>
 
 	<!-- WordPress text domain -->
 	<rule ref="WordPress.WP.I18n">
@@ -41,4 +43,13 @@
 			</property>
 		</properties>
 	</rule>
+
+    <!-- Check PHP 7.4 compatibility -->
+    <rule ref="PHPCompatibility">
+        <!-- Exclude functions that are polyfilled in WordPress or the PHP AI Client SDK -->
+        <exclude name="PHPCompatibility.FunctionUse.NewFunctions.array_is_listFound"/>
+        <exclude name="PHPCompatibility.FunctionUse.NewFunctions.str_containsFound"/>
+        <exclude name="PHPCompatibility.FunctionUse.NewFunctions.str_starts_withFound"/>
+        <exclude name="PHPCompatibility.FunctionUse.NewFunctions.str_ends_withFound"/>
+    </rule>
 </ruleset>

--- a/phpstan.neon.dist
+++ b/phpstan.neon.dist
@@ -1,0 +1,5 @@
+parameters:
+    level: max
+    paths:
+        - includes
+    treatPhpDocTypesAsCertain: false


### PR DESCRIPTION
This brings the repo setup closer to the other AI projects:

* Adjust `phpcs.xml.dist` to be more in line with the setup from `WordPress/php-ai-client`, except of course using WordPress Coding Standards instead of PER.
* Add PHPStan.
* Add `.editorconfig` following WordPress Coding Standards (matching Gutenberg setup).
* Add basic `CONTRIBUTING.md`.
* Add basic `README.md`.
* Sort Composer dependencies alphabetically.
* Add GitHub workflow for PHP linting.