### PR TITLE
Update license information to GPL-2.0-or-later

### DIFF
--- a/plugin.php
+++ b/plugin.php
@@ -8,8 +8,8 @@
  * Version: n.e.x.t
  * Author: WordPress AI Team
  * Author URI: https://make.wordpress.org/ai/
- * License: GPLv2 or later
- * License URI: https://www.gnu.org/licenses/old-licenses/gpl-2.0.html
+ * License: GPL-2.0-or-later
+ * License URI: https://spdx.org/licenses/GPL-2.0-or-later.html
  * Text Domain: wp-ai-client
  *
  * @package wp-ai-client


### PR DESCRIPTION
Following on from #3, this updates the license name and link in the main plugin.php file to match the rest of the GPL-2.0-ot-later in the rest of the codebase.