### PR TITLE
Implement `Prompt_Builder` and `Prompt_Builder_With_WP_Error`

### DIFF
--- a/includes/AI_Client.php
+++ b/includes/AI_Client.php
@@ -1,0 +1,47 @@
+<?php
+/**
+ * Class WordPress\AI_Client\AI_Client
+ *
+ * @since n.e.x.t
+ * @package wp-ai-client
+ */
+
+namespace WordPress\AI_Client;
+
+use WordPress\AI_Client\Builders\Prompt_Builder;
+use WordPress\AI_Client\Builders\Prompt_Builder_With_WP_Error;
+use WordPress\AiClient\AiClient;
+
+/**
+ * Main AI Client class providing fluent APIs for AI operations.
+ *
+ * @since n.e.x.t
+ *
+ * @phpstan-import-type Prompt from Prompt_Builder
+ */
+class AI_Client {
+
+	/**
+	 * Creates a new prompt builder for fluent API usage.
+	 *
+	 * @since n.e.x.t
+	 *
+	 * @param Prompt $prompt Optional initial prompt content.
+	 * @return Prompt_Builder The prompt builder instance.
+	 */
+	public static function prompt( $prompt = null ): Prompt_Builder {
+		return new Prompt_Builder( AiClient::defaultRegistry(), $prompt );
+	}
+
+	/**
+	 * Creates a new prompt builder for fluent API usage, returning WP_Error on errors.
+	 *
+	 * @since n.e.x.t
+	 *
+	 * @param Prompt $prompt Optional initial prompt content.
+	 * @return Prompt_Builder_With_WP_Error The prompt builder instance.
+	 */
+	public static function prompt_with_wp_error( $prompt = null ): Prompt_Builder_With_WP_Error {
+		return new Prompt_Builder_With_WP_Error( AiClient::defaultRegistry(), $prompt );
+	}
+}

--- a/includes/Builders/Prompt_Builder.php
+++ b/includes/Builders/Prompt_Builder.php
@@ -124,7 +124,7 @@ class Prompt_Builder {
 	 */
 	public function __call( string $name, array $arguments ) {
 		$callable = $this->get_builder_callable( $name );
-		return call_user_func_array( $callable, $arguments );
+		return $callable( ...$arguments );
 	}
 
 	/**

--- a/includes/Builders/Prompt_Builder.php
+++ b/includes/Builders/Prompt_Builder.php
@@ -1,0 +1,176 @@
+<?php
+/**
+ * Class WordPress\AI_Client\Builders\Prompt_Builder
+ *
+ * @since n.e.x.t
+ * @package wp-ai-client
+ */
+
+namespace WordPress\AI_Client\Builders;
+
+use BadMethodCallException;
+use WordPress\AiClient\Builders\PromptBuilder;
+use WordPress\AiClient\Files\DTO\File;
+use WordPress\AiClient\Files\Enums\FileTypeEnum;
+use WordPress\AiClient\Messages\DTO\Message;
+use WordPress\AiClient\Messages\DTO\MessagePart;
+use WordPress\AiClient\Messages\Enums\ModalityEnum;
+use WordPress\AiClient\Providers\Models\Contracts\ModelInterface;
+use WordPress\AiClient\Providers\Models\DTO\ModelConfig;
+use WordPress\AiClient\Providers\Models\Enums\CapabilityEnum;
+use WordPress\AiClient\Providers\ProviderRegistry;
+use WordPress\AiClient\Results\DTO\GenerativeAiResult;
+use WordPress\AiClient\Tools\DTO\FunctionDeclaration;
+use WordPress\AiClient\Tools\DTO\FunctionResponse;
+use WordPress\AiClient\Tools\DTO\WebSearch;
+
+/**
+ * Fluent builder for constructing AI prompts.
+ *
+ * This class provides a fluent interface for building prompts with various
+ * content types and model configurations. It automatically infers model
+ * requirements based on the features used in the prompt.
+ *
+ * Technically, this class wraps an instance of `PromptBuilder` from the WordPress agnostic PHP AI Client SDK.
+ * It adds the necessary WordPress flavoring around it, e.g. follow WordPress Coding Standards, as well as
+ * integrate with WordPress specific AI primitives such as the Abilities API.
+ *
+ * @since n.e.x.t
+ *
+ * @method self with_text(string $text) Adds text to the current message.
+ * @method self with_file($file, ?string $mimeType = null) Adds a file to the current message.
+ * @method self with_function_response(FunctionResponse $functionResponse) Adds a function response to the current message.
+ * @method self with_message_parts(MessagePart ...$parts) Adds message parts to the current message.
+ * @method self with_history(Message ...$messages) Adds conversation history messages.
+ * @method self using_model(ModelInterface $model) Sets the model to use for generation.
+ * @method self using_model_preference(...$preferredModels) Sets preferred models to evaluate in order.
+ * @method self using_model_config(ModelConfig $config) Sets the model configuration.
+ * @method self using_provider(string $providerIdOrClassName) Sets the provider to use for generation.
+ * @method self using_system_instruction(string $systemInstruction) Sets the system instruction.
+ * @method self using_max_tokens(int $maxTokens) Sets the maximum number of tokens to generate.
+ * @method self using_temperature(float $temperature) Sets the temperature for generation.
+ * @method self using_top_p(float $topP) Sets the top-p value for generation.
+ * @method self using_top_k(int $topK) Sets the top-k value for generation.
+ * @method self using_stop_sequences(string ...$stopSequences) Sets stop sequences for generation.
+ * @method self using_candidate_count(int $candidateCount) Sets the number of candidates to generate.
+ * @method self using_function_declarations(FunctionDeclaration ...$functionDeclarations) Sets the function declarations available to the model.
+ * @method self using_presence_penalty(float $presencePenalty) Sets the presence penalty for generation.
+ * @method self using_frequency_penalty(float $frequencyPenalty) Sets the frequency penalty for generation.
+ * @method self using_web_search(WebSearch $webSearch) Sets the web search configuration.
+ * @method self using_top_logprobs(?int $topLogprobs = null) Sets the top log probabilities configuration.
+ * @method self as_output_mime_type(string $mimeType) Sets the output MIME type.
+ * @method self as_output_schema(array<string, mixed> $schema) Sets the output schema.
+ * @method self as_output_modalities(ModalityEnum ...$modalities) Sets the output modalities.
+ * @method self as_output_file_type(FileTypeEnum $fileType) Sets the output file type.
+ * @method self as_json_response(?array<string, mixed> $schema = null) Configures the prompt for JSON response output.
+ * @method bool is_supported_for_text_generation() Checks if the prompt is supported for text generation.
+ * @method bool is_supported_for_image_generation() Checks if the prompt is supported for image generation.
+ * @method bool is_supported_for_text_to_speech_conversion() Checks if the prompt is supported for text to speech conversion.
+ * @method bool is_supported_for_video_generation() Checks if the prompt is supported for video generation.
+ * @method bool is_supported_for_speech_generation() Checks if the prompt is supported for speech generation.
+ * @method bool is_supported_for_music_generation() Checks if the prompt is supported for music generation.
+ * @method bool is_supported_for_embedding_generation() Checks if the prompt is supported for embedding generation.
+ * @method GenerativeAiResult generate_result(?CapabilityEnum $capability = null) Generates a result from the prompt.
+ * @method GenerativeAiResult generate_text_result() Generates a text result from the prompt.
+ * @method GenerativeAiResult generate_image_result() Generates an image result from the prompt.
+ * @method GenerativeAiResult generate_speech_result() Generates a speech result from the prompt.
+ * @method GenerativeAiResult convert_text_to_speech_result() Converts text to speech and returns the result.
+ * @method string generate_text() Generates text from the prompt.
+ * @method list<string> generate_texts(?int $candidateCount = null) Generates multiple text candidates from the prompt.
+ * @method File generate_image() Generates an image from the prompt.
+ * @method list<File> generate_images(?int $candidateCount = null) Generates multiple images from the prompt.
+ * @method File convert_text_to_speech() Converts text to speech.
+ * @method list<File> convert_text_to_speeches(?int $candidateCount = null) Converts text to multiple speech outputs.
+ * @method File generate_speech() Generates speech from the prompt.
+ * @method list<File> generate_speeches(?int $candidateCount = null) Generates multiple speech outputs from the prompt.
+ *
+ * @phpstan-import-type MessageArrayShape from Message
+ * @phpstan-import-type MessagePartArrayShape from MessagePart
+ *
+ * @phpstan-type Prompt string|MessagePart|Message|MessageArrayShape|list<string|MessagePart|MessagePartArrayShape>|list<Message>|null
+ */
+class Prompt_Builder {
+
+	/**
+	 * Wrapped prompt builder instance.
+	 *
+	 * @since n.e.x.t
+	 * @var PromptBuilder
+	 */
+	private PromptBuilder $builder;
+
+	/**
+	 * Constructor.
+	 *
+	 * @since n.e.x.t
+	 *
+	 * @param ProviderRegistry $registry The provider registry for finding suitable models.
+	 * @param Prompt           $prompt   Optional initial prompt content.
+	 */
+	public function __construct( ProviderRegistry $registry, $prompt = null ) {
+		$this->builder = new PromptBuilder( $registry, $prompt );
+	}
+
+	/**
+	 * Magic method to proxy snake_case method calls to their PHP AI Client camelCase counterparts.
+	 *
+	 * This allows WordPress developers to use snake_case naming conventions.
+	 *
+	 * @since n.e.x.t
+	 *
+	 * @param string            $name      The method name in snake_case.
+	 * @param array<int, mixed> $arguments The method arguments.
+	 * @return mixed The result of the parent method call.
+	 */
+	public function __call( string $name, array $arguments ) {
+		$callable = $this->get_builder_callable( $name );
+		return call_user_func_array( $callable, $arguments );
+	}
+
+	/**
+	 * Retrieves a callable for a given PHP AI Client SDK prompt builder method name.
+	 *
+	 * @since n.e.x.t
+	 *
+	 * @param string $name The method name in snake_case.
+	 * @return callable The callable for the specified method.
+	 *
+	 * @throws BadMethodCallException If the method does not exist.
+	 */
+	protected function get_builder_callable( string $name ): callable {
+		$camel_case_name = $this->snake_to_camel_case( $name );
+
+		if ( ! is_callable( array( $this->builder, $camel_case_name ) ) ) {
+			throw new BadMethodCallException(
+				sprintf(
+					'Method %s does not exist on %s',
+					$name, // phpcs:ignore WordPress.Security.EscapeOutput.ExceptionNotEscaped
+					get_class( $this->builder ) // phpcs:ignore WordPress.Security.EscapeOutput.ExceptionNotEscaped
+				)
+			);
+		}
+
+		// @phpstan-ignore-next-line return.type (This is a valid callable)
+		return array( $this->builder, $camel_case_name );
+	}
+
+	/**
+	 * Converts snake_case to camelCase.
+	 *
+	 * @since n.e.x.t
+	 *
+	 * @param string $snake_case The snake_case string.
+	 * @return string The camelCase string.
+	 */
+	private function snake_to_camel_case( string $snake_case ): string {
+		$parts = explode( '_', $snake_case );
+
+		$camel_case  = $parts[0];
+		$parts_count = count( $parts );
+		for ( $i = 1; $i < $parts_count; $i++ ) {
+			$camel_case .= ucfirst( $parts[ $i ] );
+		}
+
+		return $camel_case;
+	}
+}

--- a/includes/Builders/Prompt_Builder_With_WP_Error.php
+++ b/includes/Builders/Prompt_Builder_With_WP_Error.php
@@ -1,0 +1,162 @@
+<?php
+/**
+ * Class WordPress\AI_Client\Builders\Prompt_Builder_With_WP_Error
+ *
+ * @since n.e.x.t
+ * @package wp-ai-client
+ */
+
+namespace WordPress\AI_Client\Builders;
+
+use Exception;
+use WordPress\AiClient\Builders\PromptBuilder;
+use WordPress\AiClient\Files\DTO\File;
+use WordPress\AiClient\Files\Enums\FileTypeEnum;
+use WordPress\AiClient\Messages\DTO\Message;
+use WordPress\AiClient\Messages\DTO\MessagePart;
+use WordPress\AiClient\Messages\Enums\ModalityEnum;
+use WordPress\AiClient\Providers\Models\Contracts\ModelInterface;
+use WordPress\AiClient\Providers\Models\DTO\ModelConfig;
+use WordPress\AiClient\Providers\Models\Enums\CapabilityEnum;
+use WordPress\AiClient\Providers\ProviderRegistry;
+use WordPress\AiClient\Results\DTO\GenerativeAiResult;
+use WordPress\AiClient\Tools\DTO\FunctionDeclaration;
+use WordPress\AiClient\Tools\DTO\FunctionResponse;
+use WordPress\AiClient\Tools\DTO\WebSearch;
+use WP_Error;
+
+/**
+ * Fluent builder for constructing AI prompts, returning WP_Error in case of problems instead of throwing exceptions.
+ *
+ * Only the terminate methods will return a WP_Error, to not break the fluent interface. As soon as any exception is
+ * caught in a chain of method calls, the returned instance will be in an error state, and all subsequent method calls
+ * will be no-ops that just return the same error state instance. Only when a terminate method is called, the WP_Error
+ * will be returned.
+ *
+ * @since n.e.x.t
+ *
+ * @method self with_text(string $text) Adds text to the current message.
+ * @method self with_file($file, ?string $mimeType = null) Adds a file to the current message.
+ * @method self with_function_response(FunctionResponse $functionResponse) Adds a function response to the current message.
+ * @method self with_message_parts(MessagePart ...$parts) Adds message parts to the current message.
+ * @method self with_history(Message ...$messages) Adds conversation history messages.
+ * @method self using_model(ModelInterface $model) Sets the model to use for generation.
+ * @method self using_model_preference(...$preferredModels) Sets preferred models to evaluate in order.
+ * @method self using_model_config(ModelConfig $config) Sets the model configuration.
+ * @method self using_provider(string $providerIdOrClassName) Sets the provider to use for generation.
+ * @method self using_system_instruction(string $systemInstruction) Sets the system instruction.
+ * @method self using_max_tokens(int $maxTokens) Sets the maximum number of tokens to generate.
+ * @method self using_temperature(float $temperature) Sets the temperature for generation.
+ * @method self using_top_p(float $topP) Sets the top-p value for generation.
+ * @method self using_top_k(int $topK) Sets the top-k value for generation.
+ * @method self using_stop_sequences(string ...$stopSequences) Sets stop sequences for generation.
+ * @method self using_candidate_count(int $candidateCount) Sets the number of candidates to generate.
+ * @method self using_function_declarations(FunctionDeclaration ...$functionDeclarations) Sets the function declarations available to the model.
+ * @method self using_presence_penalty(float $presencePenalty) Sets the presence penalty for generation.
+ * @method self using_frequency_penalty(float $frequencyPenalty) Sets the frequency penalty for generation.
+ * @method self using_web_search(WebSearch $webSearch) Sets the web search configuration.
+ * @method self using_top_logprobs(?int $topLogprobs = null) Sets the top log probabilities configuration.
+ * @method self as_output_mime_type(string $mimeType) Sets the output MIME type.
+ * @method self as_output_schema(array<string, mixed> $schema) Sets the output schema.
+ * @method self as_output_modalities(ModalityEnum ...$modalities) Sets the output modalities.
+ * @method self as_output_file_type(FileTypeEnum $fileType) Sets the output file type.
+ * @method self as_json_response(?array<string, mixed> $schema = null) Configures the prompt for JSON response output.
+ * @method bool is_supported_for_text_generation() Checks if the prompt is supported for text generation.
+ * @method bool is_supported_for_image_generation() Checks if the prompt is supported for image generation.
+ * @method bool is_supported_for_text_to_speech_conversion() Checks if the prompt is supported for text to speech conversion.
+ * @method bool is_supported_for_video_generation() Checks if the prompt is supported for video generation.
+ * @method bool is_supported_for_speech_generation() Checks if the prompt is supported for speech generation.
+ * @method bool is_supported_for_music_generation() Checks if the prompt is supported for music generation.
+ * @method bool is_supported_for_embedding_generation() Checks if the prompt is supported for embedding generation.
+ * @method GenerativeAiResult|WP_Error generate_result(?CapabilityEnum $capability = null) Generates a result from the prompt.
+ * @method GenerativeAiResult|WP_Error generate_text_result() Generates a text result from the prompt.
+ * @method GenerativeAiResult|WP_Error generate_image_result() Generates an image result from the prompt.
+ * @method GenerativeAiResult|WP_Error generate_speech_result() Generates a speech result from the prompt.
+ * @method GenerativeAiResult|WP_Error convert_text_to_speech_result() Converts text to speech and returns the result.
+ * @method string|WP_Error generate_text() Generates text from the prompt.
+ * @method list<string>|WP_Error generate_texts(?int $candidateCount = null) Generates multiple text candidates from the prompt.
+ * @method File|WP_Error generate_image() Generates an image from the prompt.
+ * @method list<File>|WP_Error generate_images(?int $candidateCount = null) Generates multiple images from the prompt.
+ * @method File|WP_Error convert_text_to_speech() Converts text to speech.
+ * @method list<File>|WP_Error convert_text_to_speeches(?int $candidateCount = null) Converts text to multiple speech outputs.
+ * @method File|WP_Error generate_speech() Generates speech from the prompt.
+ * @method list<File>|WP_Error generate_speeches(?int $candidateCount = null) Generates multiple speech outputs from the prompt.
+ */
+class Prompt_Builder_With_WP_Error extends Prompt_Builder {
+
+	/**
+	 * WordPress error instance, if any error occurred during method calls.
+	 *
+	 * @since n.e.x.t
+	 * @var WP_Error|null
+	 */
+	private ?WP_Error $error = null;
+
+	/**
+	 * List of methods that terminate the fluent interface and return a result.
+	 *
+	 * Technically a map, simply for faster lookups.
+	 *
+	 * @since n.e.x.t
+	 * @var array<string, bool>
+	 */
+	private array $terminate_methods = array(
+		'generate_result'               => true,
+		'generate_text_result'          => true,
+		'generate_image_result'         => true,
+		'generate_speech_result'        => true,
+		'convert_text_to_speech_result' => true,
+		'generate_text'                 => true,
+		'generate_texts'                => true,
+		'generate_image'                => true,
+		'generate_images'               => true,
+		'convert_text_to_speech'        => true,
+		'convert_text_to_speeches'      => true,
+		'generate_speech'               => true,
+		'generate_speeches'             => true,
+	);
+
+	/**
+	 * Magic method to proxy snake_case method calls to their PHP AI Client camelCase counterparts.
+	 *
+	 * This allows WordPress developers to use snake_case naming conventions. It also catches any exceptions thrown,
+	 * stores them, and returns a WP_Error when a terminate method is called.
+	 *
+	 * @since n.e.x.t
+	 *
+	 * @param string            $name      The method name in snake_case.
+	 * @param array<int, mixed> $arguments The method arguments.
+	 * @return mixed The result of the parent method call.
+	 */
+	public function __call( string $name, array $arguments ) {
+		$callable = $this->get_builder_callable( $name );
+
+		/*
+		 * If an error occurred in a previous method call, either return the error for terminate methods,
+		 * or return the same instance for other methods to maintain the fluent interface.
+		 */
+		if ( null !== $this->error ) {
+			if ( isset( $this->terminate_methods[ $name ] ) ) {
+				return $this->error;
+			}
+			return $this;
+		}
+
+		try {
+			return call_user_func_array( $callable, $arguments );
+		} catch ( Exception $e ) {
+			$this->error = new WP_Error(
+				'prompt_builder_error',
+				$e->getMessage(),
+				array(
+					'exception_class' => get_class( $e ),
+				)
+			);
+
+			if ( isset( $this->terminate_methods[ $name ] ) ) {
+				return $this->error;
+			}
+			return $this;
+		}
+	}
+}

--- a/includes/Builders/Prompt_Builder_With_WP_Error.php
+++ b/includes/Builders/Prompt_Builder_With_WP_Error.php
@@ -144,7 +144,7 @@ class Prompt_Builder_With_WP_Error extends Prompt_Builder {
 		}
 
 		try {
-			return call_user_func_array( $callable, $arguments );
+			return $callable( ...$arguments );
 		} catch ( Exception $e ) {
 			$this->error = new WP_Error(
 				'prompt_builder_error',

--- a/includes/Builders/Prompt_Builder_With_WP_Error.php
+++ b/includes/Builders/Prompt_Builder_With_WP_Error.php
@@ -100,7 +100,7 @@ class Prompt_Builder_With_WP_Error extends Prompt_Builder {
 	 * @since n.e.x.t
 	 * @var array<string, bool>
 	 */
-	private array $terminate_methods = array(
+	private static array $terminate_methods = array(
 		'generate_result'               => true,
 		'generate_text_result'          => true,
 		'generate_image_result'         => true,
@@ -137,7 +137,7 @@ class Prompt_Builder_With_WP_Error extends Prompt_Builder {
 		 * or return the same instance for other methods to maintain the fluent interface.
 		 */
 		if ( null !== $this->error ) {
-			if ( isset( $this->terminate_methods[ $name ] ) ) {
+			if ( self::is_terminating_method( $name ) ) {
 				return $this->error;
 			}
 			return $this;
@@ -154,10 +154,22 @@ class Prompt_Builder_With_WP_Error extends Prompt_Builder {
 				)
 			);
 
-			if ( isset( $this->terminate_methods[ $name ] ) ) {
+			if ( self::is_terminating_method( $name ) ) {
 				return $this->error;
 			}
 			return $this;
 		}
+	}
+
+	/**
+	 * Checks if a method is a terminating method.
+	 *
+	 * @since n.e.x.t
+	 *
+	 * @param string $name The method name.
+	 * @return bool True if the method is a terminating method, false otherwise.
+	 */
+	private static function is_terminating_method( string $name ): bool {
+		return isset( self::$terminate_methods[ $name ] );
 	}
 }

--- a/includes/Builders/Prompt_Builder_With_WP_Error.php
+++ b/includes/Builders/Prompt_Builder_With_WP_Error.php
@@ -129,6 +129,7 @@ class Prompt_Builder_With_WP_Error extends Prompt_Builder {
 	 * @return mixed The result of the parent method call.
 	 */
 	public function __call( string $name, array $arguments ) {
+		// This may throw, which is fine because calls to methods that don't exist always throw.
 		$callable = $this->get_builder_callable( $name );
 
 		/*


### PR DESCRIPTION
Fixes #9

Supersedes #12 

* Uses decorator pattern to wrap original `PromptBuilder` in `Prompt_Builder`, allowing to use "snake_case" method names instead of "camelCase" method names, as per WordPress Coding Standards.
* As an alternative flavor, `Prompt_Builder_With_WP_Error` extends `Prompt_Builder` and catches any exceptions thrown in the original `PromptBuilder`, turning them into `WP_Error` return values from the terminate methods.
    * Only the terminate methods return `WP_Error` objects, to maintain the fluent interface. As soon as an exception is caught in a chain of method calls, all subsequent calls become no-ops, and only the terminate method will return the `WP_Error`.
* A very basic `AI_Client` is included to streamline instantiation of the prompt builder classes. While it is somewhat equivalent to `AiClient` from the underlying PHP AI Client SDK, there is no need for parity at this point, as most methods on `AiClient` are for more advanced use-cases. We can consider separately which other things we would want to include in the WordPress version of the class.

Developers are free to choose either class, depending on their preferences. There are no differences in their feature set, the only difference is the exception vs `WP_Error` piece.