### PR TITLE
Simplify AI client instantiation by having a central method, and warn about missing initialization

### DIFF
--- a/includes/AI_Client.php
+++ b/includes/AI_Client.php
@@ -8,8 +8,10 @@
 
 namespace WordPress\AI_Client;
 
+use WordPress\AI_Client\API_Credentials\API_Credentials_Manager;
 use WordPress\AI_Client\Builders\Prompt_Builder;
 use WordPress\AI_Client\Builders\Prompt_Builder_With_WP_Error;
+use WordPress\AI_Client\HTTP\WP_AI_Client_Discovery_Strategy;
 use WordPress\AiClient\AiClient;
 
 /**
@@ -22,6 +24,36 @@ use WordPress\AiClient\AiClient;
 class AI_Client {
 
 	/**
+	 * Indicates whether the AI Client package has been initialized.
+	 *
+	 * @since n.e.x.t
+	 * @var bool
+	 */
+	private static bool $initialized = false;
+
+	/**
+	 * Initializes the AI Client package.
+	 *
+	 * This method needs to be called by the consumer of this package, on the WordPress 'init' action hook.
+	 *
+	 * @since n.e.x.t
+	 */
+	public static function init(): void {
+		if ( self::$initialized ) {
+			return;
+		}
+
+		// Wire up the WordPress HTTP client with the PHP AI Client SDK.
+		WP_AI_Client_Discovery_Strategy::init();
+
+		// Initialize the API credentials manager and settings screen.
+		$api_credentials_manager = new API_Credentials_Manager();
+		$api_credentials_manager->initialize();
+
+		self::$initialized = true;
+	}
+
+	/**
 	 * Creates a new prompt builder for fluent API usage.
 	 *
 	 * @since n.e.x.t
@@ -30,6 +62,13 @@ class AI_Client {
 	 * @return Prompt_Builder The prompt builder instance.
 	 */
 	public static function prompt( $prompt = null ): Prompt_Builder {
+		if ( ! self::$initialized ) {
+			_doing_it_wrong(
+				__METHOD__,
+				esc_html__( 'You must call AI_Client::init() on the WordPress "init" action hook before using the AI Client.', 'wp-ai-client' ),
+				'n.e.x.t'
+			);
+		}
 		return new Prompt_Builder( AiClient::defaultRegistry(), $prompt );
 	}
 
@@ -42,6 +81,13 @@ class AI_Client {
 	 * @return Prompt_Builder_With_WP_Error The prompt builder instance.
 	 */
 	public static function prompt_with_wp_error( $prompt = null ): Prompt_Builder_With_WP_Error {
+		if ( ! self::$initialized ) {
+			_doing_it_wrong(
+				__METHOD__,
+				esc_html__( 'You must call AI_Client::init() on the WordPress "init" action hook before using the AI Client.', 'wp-ai-client' ),
+				'n.e.x.t'
+			);
+		}
 		return new Prompt_Builder_With_WP_Error( AiClient::defaultRegistry(), $prompt );
 	}
 }

--- a/plugin.php
+++ b/plugin.php
@@ -21,14 +21,4 @@ if ( ! defined( 'ABSPATH' ) ) {
 
 require_once __DIR__ . '/vendor/autoload.php';
 
-add_action(
-	'init',
-	static function () {
-		// Wire up the WordPress HTTP client with the PHP AI Client SDK.
-		WordPress\AI_Client\HTTP\WP_AI_Client_Discovery_Strategy::init();
-
-		// Initialize the API credentials manager and settings screen.
-		$api_credentials_manager = new WordPress\AI_Client\API_Credentials\API_Credentials_Manager();
-		$api_credentials_manager->initialize();
-	}
-);
+add_action( 'init', array( WordPress\AI_Client\AI_Client::class, 'init' ) );


### PR DESCRIPTION
Follow up to #13 (that must be merged first)

With this PR, it becomes possible to have a one-liner for instantiation (see the demo plugin). It'll be just as simple for any plugin to use the WP AI Client package.