### PR TITLE
Git-ignore tool-specific AI config files more comprehensively

### DIFF
--- a/.gitignore
+++ b/.gitignore
@@ -19,8 +19,13 @@ vendor/
 ############
 
 .claude/
-CLAUDE.md
+.clinerules
+.clinerules/
+.codex/
 .cursor/
+.gemini/
+.windsurf/
+CLAUDE.md
 GEMINI.md
 
 ############


### PR DESCRIPTION
This brings the ignore list of AI tools in line with the one from https://github.com/WordPress/php-ai-client