### PR TITLE
Fix Prompt_Builder method chaining

### DIFF
--- a/includes/Builders/Prompt_Builder.php
+++ b/includes/Builders/Prompt_Builder.php
@@ -124,7 +124,7 @@ class Prompt_Builder {
 	 */
 	public function __call( string $name, array $arguments ) {
 		$callable = $this->get_builder_callable( $name );
-		$result = $callable( ...$arguments );
+		$result   = $callable( ...$arguments );
 
 		// If the result is a PromptBuilder, return the current instance to allow method chaining.
 		if ( $result instanceof PromptBuilder ) {

--- a/includes/Builders/Prompt_Builder.php
+++ b/includes/Builders/Prompt_Builder.php
@@ -124,7 +124,14 @@ class Prompt_Builder {
 	 */
 	public function __call( string $name, array $arguments ) {
 		$callable = $this->get_builder_callable( $name );
-		return $callable( ...$arguments );
+		$result = $callable( ...$arguments );
+
+		// If the result is a PromptBuilder, return the current instance to allow method chaining.
+		if ( $result instanceof PromptBuilder ) {
+			return $this;
+		}
+
+		return $result;
 	}
 
 	/**

--- a/includes/Builders/Prompt_Builder_With_WP_Error.php
+++ b/includes/Builders/Prompt_Builder_With_WP_Error.php
@@ -144,7 +144,14 @@ class Prompt_Builder_With_WP_Error extends Prompt_Builder {
 		}
 
 		try {
-			return $callable( ...$arguments );
+			$result = $callable( ...$arguments );
+
+			// If the result is a PromptBuilder, return the current instance to allow method chaining.
+			if ( $result instanceof PromptBuilder ) {
+				return $this;
+			}
+
+			return $result;
 		} catch ( Exception $e ) {
 			$this->error = new WP_Error(
 				'prompt_builder_error',

--- a/tests/phpunit/tests/Builders/Prompt_Builder_Tests.php
+++ b/tests/phpunit/tests/Builders/Prompt_Builder_Tests.php
@@ -1,0 +1,294 @@
+<?php
+/**
+ * Tests for WordPress\AI_Client\Builders\Prompt_Builder
+ *
+ * @package WordPress\AI_Client
+ */
+
+namespace WordPress\AI_Client\PHPUnit\Tests\Builders;
+
+use BadMethodCallException;
+use ReflectionClass;
+use WordPress\AI_Client\Builders\Prompt_Builder;
+use WordPress\AI_Client\PHPUnit\Includes\Test_Case;
+use WordPress\AiClient\AiClient;
+use WordPress\AiClient\Builders\PromptBuilder;
+use WordPress\AiClient\Messages\DTO\Message;
+use WordPress\AiClient\Providers\Models\DTO\ModelConfig;
+
+class Prompt_Builder_Tests extends Test_Case {
+
+	/**
+	 * Test that Prompt_Builder can be instantiated.
+	 *
+	 * @since n.e.x.t
+	 */
+	public function test_instantiation(): void {
+		$registry       = AiClient::defaultRegistry();
+		$prompt_builder = new Prompt_Builder( $registry );
+
+		$this->assertInstanceOf( Prompt_Builder::class, $prompt_builder );
+
+		// Verify the wrapped builder is a PromptBuilder instance.
+		$reflection_class = new ReflectionClass( Prompt_Builder::class );
+		$builder_property = $reflection_class->getProperty( 'builder' );
+		$builder_property->setAccessible( true );
+		$wrapped_builder = $builder_property->getValue( $prompt_builder );
+
+		$this->assertInstanceOf( PromptBuilder::class, $wrapped_builder );
+	}
+
+	/**
+	 * Test that Prompt_Builder can be instantiated with initial prompt content.
+	 *
+	 * @since n.e.x.t
+	 */
+	public function test_instantiation_with_prompt(): void {
+		$registry       = AiClient::defaultRegistry();
+		$prompt_builder = new Prompt_Builder( $registry, 'Initial prompt text' );
+
+		$this->assertInstanceOf( Prompt_Builder::class, $prompt_builder );
+	}
+
+	/**
+	 * Test method chaining with fluent methods.
+	 *
+	 * This tests the bug fix where methods that return the PromptBuilder instance
+	 * should instead return the Prompt_Builder decorator to allow proper chaining.
+	 *
+	 * @since n.e.x.t
+	 */
+	public function test_method_chaining_returns_decorator(): void {
+		$registry       = AiClient::defaultRegistry();
+		$prompt_builder = new Prompt_Builder( $registry );
+
+		// Test chaining with_text which should return the decorator.
+		$result = $prompt_builder->with_text( 'Test text' );
+		$this->assertSame( $prompt_builder, $result, 'with_text should return the Prompt_Builder decorator instance' );
+		$this->assertInstanceOf( Prompt_Builder::class, $result );
+
+		// Test chaining using_system_instruction.
+		$result = $prompt_builder->using_system_instruction( 'System instruction' );
+		$this->assertSame( $prompt_builder, $result, 'using_system_instruction should return the Prompt_Builder decorator instance' );
+		$this->assertInstanceOf( Prompt_Builder::class, $result );
+
+		// Test chaining using_max_tokens.
+		$result = $prompt_builder->using_max_tokens( 100 );
+		$this->assertSame( $prompt_builder, $result, 'using_max_tokens should return the Prompt_Builder decorator instance' );
+		$this->assertInstanceOf( Prompt_Builder::class, $result );
+
+		// Test chaining using_temperature.
+		$result = $prompt_builder->using_temperature( 0.7 );
+		$this->assertSame( $prompt_builder, $result, 'using_temperature should return the Prompt_Builder decorator instance' );
+		$this->assertInstanceOf( Prompt_Builder::class, $result );
+
+		// Test chaining using_top_p.
+		$result = $prompt_builder->using_top_p( 0.9 );
+		$this->assertSame( $prompt_builder, $result, 'using_top_p should return the Prompt_Builder decorator instance' );
+		$this->assertInstanceOf( Prompt_Builder::class, $result );
+
+		// Test chaining using_top_k.
+		$result = $prompt_builder->using_top_k( 50 );
+		$this->assertSame( $prompt_builder, $result, 'using_top_k should return the Prompt_Builder decorator instance' );
+		$this->assertInstanceOf( Prompt_Builder::class, $result );
+
+		// Test chaining using_presence_penalty.
+		$result = $prompt_builder->using_presence_penalty( 0.5 );
+		$this->assertSame( $prompt_builder, $result, 'using_presence_penalty should return the Prompt_Builder decorator instance' );
+		$this->assertInstanceOf( Prompt_Builder::class, $result );
+
+		// Test chaining using_frequency_penalty.
+		$result = $prompt_builder->using_frequency_penalty( 0.5 );
+		$this->assertSame( $prompt_builder, $result, 'using_frequency_penalty should return the Prompt_Builder decorator instance' );
+		$this->assertInstanceOf( Prompt_Builder::class, $result );
+
+		// Test chaining as_output_mime_type.
+		$result = $prompt_builder->as_output_mime_type( 'application/json' );
+		$this->assertSame( $prompt_builder, $result, 'as_output_mime_type should return the Prompt_Builder decorator instance' );
+		$this->assertInstanceOf( Prompt_Builder::class, $result );
+	}
+
+	/**
+	 * Test complex method chaining scenario.
+	 *
+	 * This tests that multiple methods can be chained together fluently.
+	 *
+	 * @since n.e.x.t
+	 */
+	public function test_complex_method_chaining(): void {
+		$registry       = AiClient::defaultRegistry();
+		$prompt_builder = new Prompt_Builder( $registry );
+
+		// Chain multiple methods together.
+		$result = $prompt_builder
+			->with_text( 'Test prompt' )
+			->using_system_instruction( 'You are a helpful assistant' )
+			->using_max_tokens( 500 )
+			->using_temperature( 0.7 )
+			->using_top_p( 0.9 );
+
+		// The final result should still be the same Prompt_Builder instance.
+		$this->assertSame( $prompt_builder, $result, 'Chained methods should return the same Prompt_Builder decorator instance' );
+		$this->assertInstanceOf( Prompt_Builder::class, $result );
+	}
+
+	/**
+	 * Test that boolean-returning methods do not return the decorator.
+	 *
+	 * @since n.e.x.t
+	 */
+	public function test_boolean_methods_return_boolean(): void {
+		$registry       = AiClient::defaultRegistry();
+		$prompt_builder = new Prompt_Builder( $registry, 'Test text' );
+
+		// Boolean methods should return boolean, not the decorator.
+		$result = $prompt_builder->is_supported_for_text_generation();
+		$this->assertIsBool( $result, 'is_supported_for_text_generation should return a boolean' );
+		$this->assertNotSame( $prompt_builder, $result, 'is_supported_for_text_generation should not return the decorator' );
+	}
+
+	/**
+	 * Test snake_case to camelCase conversion.
+	 *
+	 * This tests that snake_case method names are properly converted to camelCase
+	 * when proxying to the underlying PromptBuilder.
+	 *
+	 * @since n.e.x.t
+	 */
+	public function test_snake_case_to_camel_case_conversion(): void {
+		$registry       = AiClient::defaultRegistry();
+		$prompt_builder = new Prompt_Builder( $registry );
+
+		// Test various snake_case patterns.
+		$test_cases = array(
+			'with_text'                 => 'withText',
+			'using_system_instruction'  => 'usingSystemInstruction',
+			'using_max_tokens'          => 'usingMaxTokens',
+			'as_output_mime_type'       => 'asOutputMimeType',
+			'using_model_config'        => 'usingModelConfig',
+			'with_message_parts'        => 'withMessageParts',
+			'using_stop_sequences'      => 'usingStopSequences',
+			'using_candidate_count'     => 'usingCandidateCount',
+			'using_function_declarations' => 'usingFunctionDeclarations',
+		);
+
+		$reflection_class  = new ReflectionClass( Prompt_Builder::class );
+		$conversion_method = $reflection_class->getMethod( 'snake_to_camel_case' );
+		$conversion_method->setAccessible( true );
+
+		foreach ( $test_cases as $snake_case => $expected_camel_case ) {
+			$actual_camel_case = $conversion_method->invoke( $prompt_builder, $snake_case );
+			$this->assertSame( $expected_camel_case, $actual_camel_case, "Failed converting {$snake_case} to {$expected_camel_case}" );
+		}
+	}
+
+	/**
+	 * Test that calling a non-existent method throws an exception.
+	 *
+	 * @since n.e.x.t
+	 */
+	public function test_invalid_method_throws_exception(): void {
+		$registry       = AiClient::defaultRegistry();
+		$prompt_builder = new Prompt_Builder( $registry );
+
+		$this->expectException( BadMethodCallException::class );
+		$this->expectExceptionMessage( 'Method non_existent_method does not exist' );
+
+		$prompt_builder->non_existent_method();
+	}
+
+	/**
+	 * Test that get_builder_callable returns a valid callable.
+	 *
+	 * @since n.e.x.t
+	 */
+	public function test_get_builder_callable(): void {
+		$registry       = AiClient::defaultRegistry();
+		$prompt_builder = new Prompt_Builder( $registry );
+
+		$reflection_class = new ReflectionClass( Prompt_Builder::class );
+		$callable_method  = $reflection_class->getMethod( 'get_builder_callable' );
+		$callable_method->setAccessible( true );
+
+		$callable = $callable_method->invoke( $prompt_builder, 'with_text' );
+		$this->assertTrue( is_callable( $callable ), 'get_builder_callable should return a valid callable' );
+
+		// Verify the callable is an array with the wrapped builder and the camelCase method name.
+		$this->assertIsArray( $callable );
+		$this->assertCount( 2, $callable );
+		$this->assertInstanceOf( PromptBuilder::class, $callable[0] );
+		$this->assertSame( 'withText', $callable[1] );
+	}
+
+	/**
+	 * Test that the wrapped builder is properly configured with the registry.
+	 *
+	 * @since n.e.x.t
+	 */
+	public function test_wrapped_builder_has_correct_registry(): void {
+		$registry       = AiClient::defaultRegistry();
+		$prompt_builder = new Prompt_Builder( $registry );
+
+		$reflection_class = new ReflectionClass( Prompt_Builder::class );
+		$builder_property = $reflection_class->getProperty( 'builder' );
+		$builder_property->setAccessible( true );
+		$wrapped_builder = $builder_property->getValue( $prompt_builder );
+
+		$wrapped_builder_reflection = new ReflectionClass( get_class( $wrapped_builder ) );
+		$registry_property          = $wrapped_builder_reflection->getProperty( 'registry' );
+		$registry_property->setAccessible( true );
+
+		$this->assertSame( $registry, $registry_property->getValue( $wrapped_builder ), 'Wrapped builder should have the same registry' );
+	}
+
+	/**
+	 * Test method chaining with with_history.
+	 *
+	 * @since n.e.x.t
+	 */
+	public function test_method_chaining_with_history(): void {
+		$registry       = AiClient::defaultRegistry();
+		$prompt_builder = new Prompt_Builder( $registry );
+
+		$message1 = Message::fromArray(
+			array(
+				'role'  => 'user',
+				'parts' => array(
+					array(
+						'text' => 'Hello',
+					),
+				),
+			)
+		);
+		$message2 = Message::fromArray(
+			array(
+				'role'  => 'user',
+				'parts' => array(
+					array(
+						'text' => 'How are you?',
+					),
+				),
+			)
+		);
+
+		$result = $prompt_builder->with_history( $message1, $message2 );
+		$this->assertSame( $prompt_builder, $result, 'with_history should return the Prompt_Builder decorator instance' );
+		$this->assertInstanceOf( Prompt_Builder::class, $result );
+	}
+
+	/**
+	 * Test method chaining with using_model_config.
+	 *
+	 * @since n.e.x.t
+	 */
+	public function test_method_chaining_with_model_config(): void {
+		$registry       = AiClient::defaultRegistry();
+		$prompt_builder = new Prompt_Builder( $registry );
+
+		$config = new ModelConfig( array( 'maxTokens' => 100 ) );
+
+		$result = $prompt_builder->using_model_config( $config );
+		$this->assertSame( $prompt_builder, $result, 'using_model_config should return the Prompt_Builder decorator instance' );
+		$this->assertInstanceOf( Prompt_Builder::class, $result );
+	}
+}

--- a/tests/phpunit/tests/Builders/Prompt_Builder_Tests.php
+++ b/tests/phpunit/tests/Builders/Prompt_Builder_Tests.php
@@ -161,14 +161,14 @@ class Prompt_Builder_Tests extends Test_Case {
 
 		// Test various snake_case patterns.
 		$test_cases = array(
-			'with_text'                 => 'withText',
-			'using_system_instruction'  => 'usingSystemInstruction',
-			'using_max_tokens'          => 'usingMaxTokens',
-			'as_output_mime_type'       => 'asOutputMimeType',
-			'using_model_config'        => 'usingModelConfig',
-			'with_message_parts'        => 'withMessageParts',
-			'using_stop_sequences'      => 'usingStopSequences',
-			'using_candidate_count'     => 'usingCandidateCount',
+			'with_text'                   => 'withText',
+			'using_system_instruction'    => 'usingSystemInstruction',
+			'using_max_tokens'            => 'usingMaxTokens',
+			'as_output_mime_type'         => 'asOutputMimeType',
+			'using_model_config'          => 'usingModelConfig',
+			'with_message_parts'          => 'withMessageParts',
+			'using_stop_sequences'        => 'usingStopSequences',
+			'using_candidate_count'       => 'usingCandidateCount',
 			'using_function_declarations' => 'usingFunctionDeclarations',
 		);
 

--- a/tests/phpunit/tests/Builders/Prompt_Builder_With_WP_Error_Tests.php
+++ b/tests/phpunit/tests/Builders/Prompt_Builder_With_WP_Error_Tests.php
@@ -1,0 +1,304 @@
+<?php
+/**
+ * Tests for WordPress\AI_Client\Builders\Prompt_Builder_With_WP_Error
+ *
+ * @package WordPress\AI_Client
+ */
+
+namespace WordPress\AI_Client\PHPUnit\Tests\Builders;
+
+use BadMethodCallException;
+use ReflectionClass;
+use WordPress\AI_Client\Builders\Prompt_Builder;
+use WordPress\AI_Client\Builders\Prompt_Builder_With_WP_Error;
+use WordPress\AI_Client\PHPUnit\Includes\Test_Case;
+use WordPress\AiClient\AiClient;
+use WordPress\AiClient\Builders\PromptBuilder;
+use WordPress\AiClient\Messages\DTO\Message;
+use WordPress\AiClient\Providers\Models\DTO\ModelConfig;
+use WP_Error;
+
+class Prompt_Builder_With_WP_Error_Tests extends Test_Case {
+
+	/**
+	 * Test that Prompt_Builder_With_WP_Error can be instantiated.
+	 *
+	 * @since n.e.x.t
+	 */
+	public function test_instantiation(): void {
+		$registry       = AiClient::defaultRegistry();
+		$prompt_builder = new Prompt_Builder_With_WP_Error( $registry );
+
+		$this->assertInstanceOf( Prompt_Builder_With_WP_Error::class, $prompt_builder );
+		$this->assertInstanceOf( Prompt_Builder::class, $prompt_builder );
+	}
+
+	/**
+	 * Test that Prompt_Builder_With_WP_Error can be instantiated with initial prompt content.
+	 *
+	 * @since n.e.x.t
+	 */
+	public function test_instantiation_with_prompt(): void {
+		$registry       = AiClient::defaultRegistry();
+		$prompt_builder = new Prompt_Builder_With_WP_Error( $registry, 'Initial prompt text' );
+
+		$this->assertInstanceOf( Prompt_Builder_With_WP_Error::class, $prompt_builder );
+	}
+
+	/**
+	 * Test method chaining with fluent methods.
+	 *
+	 * This tests the bug fix where methods that return the PromptBuilder instance
+	 * should instead return the Prompt_Builder_With_WP_Error decorator to allow proper chaining.
+	 *
+	 * @since n.e.x.t
+	 */
+	public function test_method_chaining_returns_decorator(): void {
+		$registry       = AiClient::defaultRegistry();
+		$prompt_builder = new Prompt_Builder_With_WP_Error( $registry );
+
+		// Test chaining with_text which should return the decorator.
+		$result = $prompt_builder->with_text( 'Test text' );
+		$this->assertSame( $prompt_builder, $result, 'with_text should return the Prompt_Builder_With_WP_Error decorator instance' );
+		$this->assertInstanceOf( Prompt_Builder_With_WP_Error::class, $result );
+
+		// Test chaining using_system_instruction.
+		$result = $prompt_builder->using_system_instruction( 'System instruction' );
+		$this->assertSame( $prompt_builder, $result, 'using_system_instruction should return the Prompt_Builder_With_WP_Error decorator instance' );
+		$this->assertInstanceOf( Prompt_Builder_With_WP_Error::class, $result );
+
+		// Test chaining using_max_tokens.
+		$result = $prompt_builder->using_max_tokens( 100 );
+		$this->assertSame( $prompt_builder, $result, 'using_max_tokens should return the Prompt_Builder_With_WP_Error decorator instance' );
+		$this->assertInstanceOf( Prompt_Builder_With_WP_Error::class, $result );
+
+		// Test chaining using_temperature.
+		$result = $prompt_builder->using_temperature( 0.7 );
+		$this->assertSame( $prompt_builder, $result, 'using_temperature should return the Prompt_Builder_With_WP_Error decorator instance' );
+		$this->assertInstanceOf( Prompt_Builder_With_WP_Error::class, $result );
+
+		// Test chaining using_top_p.
+		$result = $prompt_builder->using_top_p( 0.9 );
+		$this->assertSame( $prompt_builder, $result, 'using_top_p should return the Prompt_Builder_With_WP_Error decorator instance' );
+		$this->assertInstanceOf( Prompt_Builder_With_WP_Error::class, $result );
+
+		// Test chaining using_top_k.
+		$result = $prompt_builder->using_top_k( 50 );
+		$this->assertSame( $prompt_builder, $result, 'using_top_k should return the Prompt_Builder_With_WP_Error decorator instance' );
+		$this->assertInstanceOf( Prompt_Builder_With_WP_Error::class, $result );
+
+		// Test chaining using_presence_penalty.
+		$result = $prompt_builder->using_presence_penalty( 0.5 );
+		$this->assertSame( $prompt_builder, $result, 'using_presence_penalty should return the Prompt_Builder_With_WP_Error decorator instance' );
+		$this->assertInstanceOf( Prompt_Builder_With_WP_Error::class, $result );
+
+		// Test chaining using_frequency_penalty.
+		$result = $prompt_builder->using_frequency_penalty( 0.5 );
+		$this->assertSame( $prompt_builder, $result, 'using_frequency_penalty should return the Prompt_Builder_With_WP_Error decorator instance' );
+		$this->assertInstanceOf( Prompt_Builder_With_WP_Error::class, $result );
+
+		// Test chaining as_output_mime_type.
+		$result = $prompt_builder->as_output_mime_type( 'application/json' );
+		$this->assertSame( $prompt_builder, $result, 'as_output_mime_type should return the Prompt_Builder_With_WP_Error decorator instance' );
+		$this->assertInstanceOf( Prompt_Builder_With_WP_Error::class, $result );
+	}
+
+	/**
+	 * Test complex method chaining scenario.
+	 *
+	 * This tests that multiple methods can be chained together fluently.
+	 *
+	 * @since n.e.x.t
+	 */
+	public function test_complex_method_chaining(): void {
+		$registry       = AiClient::defaultRegistry();
+		$prompt_builder = new Prompt_Builder_With_WP_Error( $registry );
+
+		// Chain multiple methods together.
+		$result = $prompt_builder
+			->with_text( 'Test prompt' )
+			->using_system_instruction( 'You are a helpful assistant' )
+			->using_max_tokens( 500 )
+			->using_temperature( 0.7 )
+			->using_top_p( 0.9 );
+
+		// The final result should still be the same Prompt_Builder_With_WP_Error instance.
+		$this->assertSame( $prompt_builder, $result, 'Chained methods should return the same Prompt_Builder_With_WP_Error decorator instance' );
+		$this->assertInstanceOf( Prompt_Builder_With_WP_Error::class, $result );
+	}
+
+	/**
+	 * Test that boolean-returning methods do not return the decorator.
+	 *
+	 * @since n.e.x.t
+	 */
+	public function test_boolean_methods_return_boolean(): void {
+		$registry       = AiClient::defaultRegistry();
+		$prompt_builder = new Prompt_Builder_With_WP_Error( $registry, 'Test text' );
+
+		// Boolean methods should return boolean, not the decorator.
+		$result = $prompt_builder->is_supported_for_text_generation();
+		$this->assertIsBool( $result, 'is_supported_for_text_generation should return a boolean' );
+		$this->assertNotSame( $prompt_builder, $result, 'is_supported_for_text_generation should not return the decorator' );
+	}
+
+	/**
+	 * Test that calling a non-existent method throws an exception.
+	 *
+	 * @since n.e.x.t
+	 */
+	public function test_invalid_method_throws_exception(): void {
+		$registry       = AiClient::defaultRegistry();
+		$prompt_builder = new Prompt_Builder_With_WP_Error( $registry );
+
+		$this->expectException( BadMethodCallException::class );
+		$this->expectExceptionMessage( 'Method non_existent_method does not exist' );
+
+		$prompt_builder->non_existent_method();
+	}
+
+	/**
+	 * Test method chaining with with_history.
+	 *
+	 * @since n.e.x.t
+	 */
+	public function test_method_chaining_with_history(): void {
+		$registry       = AiClient::defaultRegistry();
+		$prompt_builder = new Prompt_Builder_With_WP_Error( $registry );
+
+		$message1 = Message::fromArray(
+			array(
+				'role'  => 'user',
+				'parts' => array(
+					array(
+						'text' => 'Hello',
+					),
+				),
+			)
+		);
+		$message2 = Message::fromArray(
+			array(
+				'role'  => 'user',
+				'parts' => array(
+					array(
+						'text' => 'How are you?',
+					),
+				),
+			)
+		);
+
+		$result = $prompt_builder->with_history( $message1, $message2 );
+		$this->assertSame( $prompt_builder, $result, 'with_history should return the Prompt_Builder_With_WP_Error decorator instance' );
+		$this->assertInstanceOf( Prompt_Builder_With_WP_Error::class, $result );
+	}
+
+	/**
+	 * Test method chaining with using_model_config.
+	 *
+	 * @since n.e.x.t
+	 */
+	public function test_method_chaining_with_model_config(): void {
+		$registry       = AiClient::defaultRegistry();
+		$prompt_builder = new Prompt_Builder_With_WP_Error( $registry );
+
+		$config = new ModelConfig( array( 'maxTokens' => 100 ) );
+
+		$result = $prompt_builder->using_model_config( $config );
+		$this->assertSame( $prompt_builder, $result, 'using_model_config should return the Prompt_Builder_With_WP_Error decorator instance' );
+		$this->assertInstanceOf( Prompt_Builder_With_WP_Error::class, $result );
+	}
+
+	/**
+	 * Test that once in error state, subsequent fluent calls return the same instance.
+	 *
+	 * This test simulates an error state by directly setting the error property,
+	 * since fluent methods typically don't throw exceptions.
+	 *
+	 * @since n.e.x.t
+	 */
+	public function test_error_state_fluent_calls_return_same_instance(): void {
+		$registry       = AiClient::defaultRegistry();
+		$prompt_builder = new Prompt_Builder_With_WP_Error( $registry );
+
+		// Simulate an error state by directly setting the error property.
+		$reflection_class = new ReflectionClass( Prompt_Builder_With_WP_Error::class );
+		$error_property   = $reflection_class->getProperty( 'error' );
+		$error_property->setAccessible( true );
+		$error_property->setValue( $prompt_builder, new WP_Error( 'test_error', 'Test error message' ) );
+
+		// Subsequent fluent calls should return the same instance.
+		$result = $prompt_builder->with_text( 'Test' );
+		$this->assertSame( $prompt_builder, $result, 'Fluent method should return same instance when in error state' );
+
+		$result = $prompt_builder->using_max_tokens( 100 );
+		$this->assertSame( $prompt_builder, $result, 'Fluent method should return same instance when in error state' );
+	}
+
+	/**
+	 * Test that terminating methods return WP_Error when in error state.
+	 *
+	 * This test simulates an error state by directly setting the error property.
+	 *
+	 * @since n.e.x.t
+	 */
+	public function test_terminating_methods_return_wp_error_in_error_state(): void {
+		$registry       = AiClient::defaultRegistry();
+		$prompt_builder = new Prompt_Builder_With_WP_Error( $registry );
+
+		// Simulate an error state by directly setting the error property.
+		$test_error       = new WP_Error( 'test_error', 'Test error message' );
+		$reflection_class = new ReflectionClass( Prompt_Builder_With_WP_Error::class );
+		$error_property   = $reflection_class->getProperty( 'error' );
+		$error_property->setAccessible( true );
+		$error_property->setValue( $prompt_builder, $test_error );
+
+		// Terminating methods should return the WP_Error.
+		$result = $prompt_builder->generate_text();
+		$this->assertInstanceOf( WP_Error::class, $result, 'generate_text should return WP_Error when in error state' );
+		$this->assertSame( $test_error, $result, 'Should return the same WP_Error instance' );
+	}
+
+	/**
+	 * Test that exception in terminating method is caught and returned as WP_Error.
+	 *
+	 * @since n.e.x.t
+	 */
+	public function test_exception_in_terminating_method_caught_and_returned(): void {
+		$registry       = AiClient::defaultRegistry();
+		$prompt_builder = new Prompt_Builder_With_WP_Error( $registry );
+
+		// Calling a terminating method without proper setup should cause an exception.
+		// This will fail because no model/provider is configured.
+		$error = $prompt_builder->generate_text();
+
+		$this->assertInstanceOf( WP_Error::class, $error, 'generate_text should return WP_Error when exception occurs' );
+		$this->assertSame( 'prompt_builder_error', $error->get_error_code() );
+
+		// Check that error data contains exception class.
+		$error_data = $error->get_error_data();
+		$this->assertIsArray( $error_data );
+		$this->assertArrayHasKey( 'exception_class', $error_data );
+		$this->assertNotEmpty( $error_data['exception_class'] );
+	}
+
+	/**
+	 * Test that the wrapped builder is properly configured with the registry.
+	 *
+	 * @since n.e.x.t
+	 */
+	public function test_wrapped_builder_has_correct_registry(): void {
+		$registry       = AiClient::defaultRegistry();
+		$prompt_builder = new Prompt_Builder_With_WP_Error( $registry );
+
+		$reflection_class = new ReflectionClass( Prompt_Builder::class );
+		$builder_property = $reflection_class->getProperty( 'builder' );
+		$builder_property->setAccessible( true );
+		$wrapped_builder = $builder_property->getValue( $prompt_builder );
+
+		$wrapped_builder_reflection = new ReflectionClass( get_class( $wrapped_builder ) );
+		$registry_property          = $wrapped_builder_reflection->getProperty( 'registry' );
+		$registry_property->setAccessible( true );
+
+		$this->assertSame( $registry, $registry_property->getValue( $wrapped_builder ), 'Wrapped builder should have the same registry' );
+	}
+}


### PR DESCRIPTION
As well described in #19, there was an issue with chaining `Prompt_Builder` fluent methods as the underlying `PromptBuilder` instance was being returned instead of the decorator.

This resolves the issue and also adds unit tests, as this would've been caught had tests been present.

Fixes #19