### PR TITLE
Update to PHP AI Client 0.2.1

### DIFF
--- a/composer.lock
+++ b/composer.lock
@@ -489,16 +489,16 @@
         },
         {
             "name": "wordpress/php-ai-client",
-            "version": "0.2.0",
+            "version": "0.2.1",
             "source": {
                 "type": "git",
                 "url": "https://github.com/WordPress/php-ai-client.git",
-                "reference": "81a104a9bc5f887e3fbecea6e0d9cd8eab3be0b2"
+                "reference": "61ecd7c86329d0cc3d17567891f363d8f3fc3be6"
             },
             "dist": {
                 "type": "zip",
-                "url": "https://api.github.com/repos/WordPress/php-ai-client/zipball/81a104a9bc5f887e3fbecea6e0d9cd8eab3be0b2",
-                "reference": "81a104a9bc5f887e3fbecea6e0d9cd8eab3be0b2",
+                "url": "https://api.github.com/repos/WordPress/php-ai-client/zipball/61ecd7c86329d0cc3d17567891f363d8f3fc3be6",
+                "reference": "61ecd7c86329d0cc3d17567891f363d8f3fc3be6",
                 "shasum": ""
             },
             "require": {
@@ -552,7 +552,7 @@
                 "issues": "https://github.com/WordPress/php-ai-client/issues",
                 "source": "https://github.com/WordPress/php-ai-client"
             },
-            "time": "2025-10-21T00:05:14+00:00"
+            "time": "2025-11-17T18:04:50+00:00"
         }
     ],
     "packages-dev": [
@@ -3485,14 +3485,14 @@
     ],
     "aliases": [],
     "minimum-stability": "dev",
-    "stability-flags": [],
+    "stability-flags": {},
     "prefer-stable": true,
     "prefer-lowest": false,
     "platform": {
         "php": ">=7.4",
         "ext-json": "*"
     },
-    "platform-dev": [],
+    "platform-dev": {},
     "platform-overrides": {
         "php": "7.4"
     },


### PR DESCRIPTION
This updates the PHP AI Client to 0.2.1, mostly because it contains a fix for the Google provider which is important to get out.