### PR TITLE
Adds Abilities API support

### DIFF
--- a/.github/workflows/php-test.yml
+++ b/.github/workflows/php-test.yml
@@ -44,7 +44,7 @@ jobs:
         - '7.4'
         - '8.0'
         - '8.4'
-        wordpress: [ 'latest' ]
+        wordpress: [ 'trunk' ]
         multisite: [ false, true ]
         experimental: [false]
         include:

--- a/.wp-env.json
+++ b/.wp-env.json
@@ -1,4 +1,4 @@
 {
-	"core": null,
+	"core": "WordPress/WordPress#6.9-branch",
 	"plugins": [ "." ]
 }

--- a/includes/Builders/Helpers/Ability_Function_Resolver.php
+++ b/includes/Builders/Helpers/Ability_Function_Resolver.php
@@ -1,0 +1,177 @@
+<?php
+/**
+ * Ability_Function_Resolver class.
+ *
+ * @since n.e.x.t
+ * @package wp-ai-client
+ */
+
+namespace WordPress\AI_Client\Builders\Helpers;
+
+use WordPress\AiClient\Messages\DTO\Message;
+use WordPress\AiClient\Messages\DTO\MessagePart;
+use WordPress\AiClient\Messages\DTO\ModelMessage;
+use WordPress\AiClient\Tools\DTO\FunctionCall;
+use WordPress\AiClient\Tools\DTO\FunctionResponse;
+use WP_Ability;
+
+/**
+ * Resolves and executes WordPress Abilities API function calls from AI models.
+ *
+ * @since n.e.x.t
+ */
+class Ability_Function_Resolver {
+
+	/**
+	 * Prefix used to identify ability function calls.
+	 *
+	 * @since n.e.x.t
+	 */
+	private const ABILITY_PREFIX = 'wpab__';
+
+	/**
+	 * Checks if a function call is an ability call.
+	 *
+	 * @since n.e.x.t
+	 *
+	 * @param FunctionCall $call The function call to check.
+	 * @return bool True if the function call is an ability call, false otherwise.
+	 */
+	public function is_ability_call( FunctionCall $call ): bool {
+		$name = $call->getName();
+		if ( null === $name ) {
+			return false;
+		}
+
+		return str_starts_with( $name, self::ABILITY_PREFIX );
+	}
+
+	/**
+	 * Executes a WordPress ability from a function call.
+	 *
+	 * @since n.e.x.t
+	 *
+	 * @param FunctionCall $call The function call to execute.
+	 * @return FunctionResponse The response from executing the ability.
+	 */
+	public function execute_ability( FunctionCall $call ): FunctionResponse {
+		$function_name = $call->getName() ?? 'unknown';
+		$function_id   = $call->getId() ?? 'unknown';
+
+		// Validate that this is an ability call.
+		if ( ! $this->is_ability_call( $call ) ) {
+			return new FunctionResponse(
+				$function_id,
+				$function_name,
+				array(
+					'error' => 'Not an ability function call',
+					'code'  => 'invalid_ability_call',
+				)
+			);
+		}
+
+		// Convert function name to ability name.
+		$ability_name = $this->function_name_to_ability_name( $function_name );
+
+		// Get the ability.
+		$ability = wp_get_ability( $ability_name );
+
+		if ( ! $ability instanceof WP_Ability ) {
+			return new FunctionResponse(
+				$function_id,
+				$function_name,
+				array(
+					'error' => sprintf( 'Ability "%s" not found', $ability_name ),
+					'code'  => 'ability_not_found',
+				)
+			);
+		}
+
+		// Execute the ability.
+		$args   = $call->getArgs();
+		$result = $ability->execute( $args );
+
+		// Handle WP_Error responses.
+		if ( is_wp_error( $result ) ) {
+			return new FunctionResponse(
+				$function_id,
+				$function_name,
+				array(
+					'error' => $result->get_error_message(),
+					'code'  => $result->get_error_code(),
+					'data'  => $result->get_error_data(),
+				)
+			);
+		}
+
+		// Return successful response.
+		return new FunctionResponse(
+			$function_id,
+			$function_name,
+			$result
+		);
+	}
+
+	/**
+	 * Checks if a message contains any ability function calls.
+	 *
+	 * @since n.e.x.t
+	 *
+	 * @param Message $message The message to check.
+	 * @return bool True if the message contains ability calls, false otherwise.
+	 */
+	public function has_ability_calls( Message $message ): bool {
+		foreach ( $message->getParts() as $part ) {
+			if ( $part->getType()->isFunctionCall() ) {
+				$function_call = $part->getFunctionCall();
+				if ( $function_call instanceof FunctionCall && $this->is_ability_call( $function_call ) ) {
+					return true;
+				}
+			}
+		}
+
+		return false;
+	}
+
+	/**
+	 * Executes all ability function calls in a message.
+	 *
+	 * @since n.e.x.t
+	 *
+	 * @param Message $message The message containing function calls.
+	 * @return Message A new message with function responses.
+	 */
+	public function execute_abilities( Message $message ): Message {
+		$response_parts = array();
+
+		foreach ( $message->getParts() as $part ) {
+			if ( $part->getType()->isFunctionCall() ) {
+				$function_call = $part->getFunctionCall();
+				if ( $function_call instanceof FunctionCall ) {
+					$function_response = $this->execute_ability( $function_call );
+					$response_parts[]  = new MessagePart( $function_response );
+				}
+			}
+		}
+
+		return new ModelMessage( $response_parts );
+	}
+
+	/**
+	 * Converts a function name to an ability name.
+	 *
+	 * Transforms "wpab__tec__create_event" to "tec/create_event".
+	 *
+	 * @since n.e.x.t
+	 *
+	 * @param string $function_name The function name to convert.
+	 * @return string The ability name.
+	 */
+	private function function_name_to_ability_name( string $function_name ): string {
+		// Remove the ability prefix.
+		$without_prefix = substr( $function_name, strlen( self::ABILITY_PREFIX ) );
+
+		// Convert double underscores to forward slashes.
+		return str_replace( '__', '/', $without_prefix );
+	}
+}

--- a/includes/Builders/Helpers/Ability_Function_Resolver.php
+++ b/includes/Builders/Helpers/Ability_Function_Resolver.php
@@ -10,7 +10,7 @@ namespace WordPress\AI_Client\Builders\Helpers;
 
 use WordPress\AiClient\Messages\DTO\Message;
 use WordPress\AiClient\Messages\DTO\MessagePart;
-use WordPress\AiClient\Messages\DTO\ModelMessage;
+use WordPress\AiClient\Messages\DTO\UserMessage;
 use WordPress\AiClient\Tools\DTO\FunctionCall;
 use WordPress\AiClient\Tools\DTO\FunctionResponse;
 use WP_Ability;
@@ -154,7 +154,7 @@ class Ability_Function_Resolver {
 			}
 		}
 
-		return new ModelMessage( $response_parts );
+		return new UserMessage( $response_parts );
 	}
 
 	/**

--- a/includes/Builders/Helpers/Ability_Function_Resolver.php
+++ b/includes/Builders/Helpers/Ability_Function_Resolver.php
@@ -37,7 +37,7 @@ class Ability_Function_Resolver {
 	 * @param FunctionCall $call The function call to check.
 	 * @return bool True if the function call is an ability call, false otherwise.
 	 */
-	public function is_ability_call( FunctionCall $call ): bool {
+	public static function is_ability_call( FunctionCall $call ): bool {
 		$name = $call->getName();
 		if ( null === $name ) {
 			return false;
@@ -54,12 +54,12 @@ class Ability_Function_Resolver {
 	 * @param FunctionCall $call The function call to execute.
 	 * @return FunctionResponse The response from executing the ability.
 	 */
-	public function execute_ability( FunctionCall $call ): FunctionResponse {
+	public static function execute_ability( FunctionCall $call ): FunctionResponse {
 		$function_name = $call->getName() ?? 'unknown';
 		$function_id   = $call->getId() ?? 'unknown';
 
 		// Validate that this is an ability call.
-		if ( ! $this->is_ability_call( $call ) ) {
+		if ( ! self::is_ability_call( $call ) ) {
 			return new FunctionResponse(
 				$function_id,
 				$function_name,
@@ -71,7 +71,7 @@ class Ability_Function_Resolver {
 		}
 
 		// Convert function name to ability name.
-		$ability_name = $this->function_name_to_ability_name( $function_name );
+		$ability_name = self::function_name_to_ability_name( $function_name );
 
 		// Get the ability.
 		$ability = wp_get_ability( $ability_name );
@@ -120,11 +120,11 @@ class Ability_Function_Resolver {
 	 * @param Message $message The message to check.
 	 * @return bool True if the message contains ability calls, false otherwise.
 	 */
-	public function has_ability_calls( Message $message ): bool {
+	public static function has_ability_calls( Message $message ): bool {
 		foreach ( $message->getParts() as $part ) {
 			if ( $part->getType()->isFunctionCall() ) {
 				$function_call = $part->getFunctionCall();
-				if ( $function_call instanceof FunctionCall && $this->is_ability_call( $function_call ) ) {
+				if ( $function_call instanceof FunctionCall && self::is_ability_call( $function_call ) ) {
 					return true;
 				}
 			}
@@ -141,20 +141,34 @@ class Ability_Function_Resolver {
 	 * @param Message $message The message containing function calls.
 	 * @return Message A new message with function responses.
 	 */
-	public function execute_abilities( Message $message ): Message {
+	public static function execute_abilities( Message $message ): Message {
 		$response_parts = array();
 
 		foreach ( $message->getParts() as $part ) {
 			if ( $part->getType()->isFunctionCall() ) {
 				$function_call = $part->getFunctionCall();
 				if ( $function_call instanceof FunctionCall ) {
-					$function_response = $this->execute_ability( $function_call );
+					$function_response = self::execute_ability( $function_call );
 					$response_parts[]  = new MessagePart( $function_response );
 				}
 			}
 		}
 
 		return new UserMessage( $response_parts );
+	}
+
+	/**
+	 * Converts an ability name to a function name.
+	 *
+	 * Transforms "tec/create_event" to "wpab__tec__create_event".
+	 *
+	 * @since n.e.x.t
+	 *
+	 * @param string $ability_name The ability name to convert.
+	 * @return string The function name.
+	 */
+	public static function ability_name_to_function_name( string $ability_name ): string {
+		return self::ABILITY_PREFIX . str_replace( '/', '__', $ability_name );
 	}
 
 	/**
@@ -167,7 +181,7 @@ class Ability_Function_Resolver {
 	 * @param string $function_name The function name to convert.
 	 * @return string The ability name.
 	 */
-	private function function_name_to_ability_name( string $function_name ): string {
+	private static function function_name_to_ability_name( string $function_name ): string {
 		// Remove the ability prefix.
 		$without_prefix = substr( $function_name, strlen( self::ABILITY_PREFIX ) );
 

--- a/includes/Builders/Prompt_Builder.php
+++ b/includes/Builders/Prompt_Builder.php
@@ -23,6 +23,8 @@ use WordPress\AiClient\Results\DTO\GenerativeAiResult;
 use WordPress\AiClient\Tools\DTO\FunctionDeclaration;
 use WordPress\AiClient\Tools\DTO\FunctionResponse;
 use WordPress\AiClient\Tools\DTO\WebSearch;
+use WordPress\AI_Client\Builders\Helpers\Ability_Function_Resolver;
+use WP_Ability;
 
 /**
  * Fluent builder for constructing AI prompts.
@@ -109,6 +111,36 @@ class Prompt_Builder {
 	 */
 	public function __construct( ProviderRegistry $registry, $prompt = null ) {
 		$this->builder = new PromptBuilder( $registry, $prompt );
+	}
+
+	/**
+	 * Registers WordPress abilities as function declarations for the AI model.
+	 *
+	 * Converts each WP_Ability to a FunctionDeclaration using the wpab__ prefix
+	 * naming convention and passes them to the underlying prompt builder.
+	 *
+	 * @since n.e.x.t
+	 *
+	 * @param WP_Ability ...$abilities The abilities to register.
+	 * @return self The current instance for method chaining.
+	 */
+	public function using_ability( WP_Ability ...$abilities ): self {
+		$declarations = array();
+
+		foreach ( $abilities as $ability ) {
+			$function_name = Ability_Function_Resolver::ability_name_to_function_name( $ability->get_name() );
+			$input_schema  = $ability->get_input_schema();
+
+			$declarations[] = new FunctionDeclaration(
+				$function_name,
+				$ability->get_description(),
+				! empty( $input_schema ) ? $input_schema : null
+			);
+		}
+
+		$this->builder->usingFunctionDeclarations( ...$declarations );
+
+		return $this;
 	}
 
 	/**

--- a/includes/Builders/Prompt_Builder.php
+++ b/includes/Builders/Prompt_Builder.php
@@ -121,13 +121,21 @@ class Prompt_Builder {
 	 *
 	 * @since n.e.x.t
 	 *
-	 * @param WP_Ability ...$abilities The abilities to register.
+	 * @param WP_Ability|string ...$abilities The abilities to register, either as WP_Ability objects or ability name strings.
 	 * @return self The current instance for method chaining.
 	 */
-	public function using_ability( WP_Ability ...$abilities ): self {
+	public function using_ability( ...$abilities ): self {
 		$declarations = array();
 
 		foreach ( $abilities as $ability ) {
+			if ( is_string( $ability ) ) {
+				$ability = wp_get_ability( $ability );
+			}
+
+			if ( ! $ability instanceof WP_Ability ) {
+				continue;
+			}
+
 			$function_name = Ability_Function_Resolver::ability_name_to_function_name( $ability->get_name() );
 			$input_schema  = $ability->get_input_schema();
 
@@ -138,7 +146,9 @@ class Prompt_Builder {
 			);
 		}
 
-		$this->builder->usingFunctionDeclarations( ...$declarations );
+		if ( ! empty( $declarations ) ) {
+			return $this->using_function_declarations( ...$declarations );
+		}
 
 		return $this;
 	}

--- a/package-lock.json
+++ b/package-lock.json
@@ -543,6 +543,7 @@
 			"integrity": "sha512-aPTXCrfwnDLj4VvXrm+UUCQjNEvJgNA8s5F1cvwQU+3KNltTOkBm1j30uNLyqqPNe7gE3KFzImYoZEfLhp4Yow==",
 			"dev": true,
 			"license": "MIT",
+			"peer": true,
 			"dependencies": {
 				"undici-types": "~7.10.0"
 			}

--- a/phpstan.neon.dist
+++ b/phpstan.neon.dist
@@ -5,5 +5,14 @@ parameters:
   scanFiles:
     - vendor/php-stubs/wordpress-stubs/wordpress-stubs.php
   treatPhpDocTypesAsCertain: false
+  ignoreErrors:
+    # TEMPORARY: WordPress 6.9 Abilities API functions not yet in stubs
+    - '#Function wp_get_ability not found\.#'
+    - '#Class WP_Ability not found\.#'
+    - '#on an unknown class WP_Ability\.#'
+    - '#has invalid type WP_Ability\.#'
+    -
+      message: '#expects .*, mixed given\.#'
+      path: includes/Builders/Prompt_Builder.php
 includes:
   - vendor/szepeviktor/phpstan-wordpress/extension.neon

--- a/tests/phpunit/bootstrap.php
+++ b/tests/phpunit/bootstrap.php
@@ -25,5 +25,121 @@ $GLOBALS['wp_tests_options'] = array( // phpcs:ignore WordPress.NamingConvention
 	'active_plugins' => array( basename( WP_AI_CLIENT_PROJECT_DIR ) . '/plugin.php' ),
 );
 
+// Load WordPress test functions to use tests_add_filter().
+require_once $wp_ai_client_test_root . '/includes/functions.php';
+
+/**
+ * Registers a test category for the Abilities API.
+ *
+ * Must be hooked before WordPress bootstrap loads.
+ */
+tests_add_filter(
+	'wp_abilities_api_categories_init',
+	static function () {
+		wp_register_ability_category(
+			'wpaiclienttests',
+			array(
+				'label'       => 'WP AI Client Tests',
+				'description' => 'Test abilities for the WP AI Client plugin.',
+			)
+		);
+	}
+);
+
+/**
+ * Registers test abilities for the Abilities API.
+ *
+ * Must be hooked before WordPress bootstrap loads.
+ */
+tests_add_filter(
+	'wp_abilities_api_init',
+	static function () {
+		// Simple ability with no parameters.
+		wp_register_ability(
+			'wpaiclienttests/simple',
+			array(
+				'label'               => 'Simple Test Ability',
+				'description'         => 'A simple test ability with no parameters.',
+				'category'            => 'wpaiclienttests',
+				'permission_callback' => '__return_true',
+				'input_schema'        => array(
+					'type'       => 'object',
+					'properties' => array(),
+				),
+				'execute_callback'    => static function () {
+					return array( 'success' => true );
+				},
+			)
+		);
+
+		// Ability with input schema.
+		wp_register_ability(
+			'wpaiclienttests/with-params',
+			array(
+				'label'               => 'Test Ability With Parameters',
+				'description'         => 'A test ability that accepts parameters.',
+				'category'            => 'wpaiclienttests',
+				'permission_callback' => '__return_true',
+				'input_schema'        => array(
+					'type'       => 'object',
+					'properties' => array(
+						'title'       => array(
+							'type'        => 'string',
+							'description' => 'The title of the item.',
+						),
+						'description' => array(
+							'type'        => 'string',
+							'description' => 'The description of the item.',
+						),
+					),
+					'required'   => array( 'title' ),
+				),
+				'execute_callback'    => static function ( $input ) {
+					return array(
+						'success' => true,
+						'title'   => $input['title'] ?? '',
+					);
+				},
+			)
+		);
+
+		// Ability that returns an error.
+		wp_register_ability(
+			'wpaiclienttests/returns-error',
+			array(
+				'label'               => 'Test Ability That Returns Error',
+				'description'         => 'A test ability that always returns a WP_Error.',
+				'category'            => 'wpaiclienttests',
+				'permission_callback' => '__return_true',
+				'input_schema'        => array(
+					'type'       => 'object',
+					'properties' => array(),
+				),
+				'execute_callback'    => static function () {
+					return new \WP_Error( 'test_error', 'This is a test error message.' );
+				},
+			)
+		);
+
+		// Ability with hyphenated name (for testing name-to-function conversion).
+		wp_register_ability(
+			'wpaiclienttests/hyphen-test',
+			array(
+				'label'               => 'Hyphenated Name Test Ability',
+				'description'         => 'A test ability with hyphens in the name.',
+				'category'            => 'wpaiclienttests',
+				'permission_callback' => '__return_true',
+				'input_schema'        => array(
+					'type'       => 'object',
+					'properties' => array(),
+				),
+				'execute_callback'    => static function () {
+					return array( 'hyphenated' => true );
+				},
+			)
+		);
+	}
+);
+
 // Start up the WP testing environment.
 require $wp_ai_client_test_root . '/includes/bootstrap.php';

--- a/tests/phpunit/tests/Abilities/Ability_Function_Resolver_Tests.php
+++ b/tests/phpunit/tests/Abilities/Ability_Function_Resolver_Tests.php
@@ -1,0 +1,634 @@
+<?php
+/**
+ * Tests for WordPress\AI_Client\Builders\Helpers\Ability_Function_Resolver
+ *
+ * @package WordPress\AI_Client
+ */
+
+namespace WordPress\AI_Client\PHPUnit\Tests\Abilities;
+
+use WordPress\AI_Client\Builders\Helpers\Ability_Function_Resolver;
+use WordPress\AI_Client\PHPUnit\Includes\Test_Case;
+use WordPress\AiClient\Messages\DTO\Message;
+use WordPress\AiClient\Messages\DTO\MessagePart;
+use WordPress\AiClient\Messages\DTO\ModelMessage;
+use WordPress\AiClient\Messages\DTO\UserMessage;
+use WordPress\AiClient\Messages\Enums\MessageRoleEnum;
+use WordPress\AiClient\Tools\DTO\FunctionCall;
+use WordPress\AiClient\Tools\DTO\FunctionResponse;
+use WP_Ability;
+use WP_Error;
+
+/**
+ * Test class for Ability_Function_Resolver.
+ */
+class Ability_Function_Resolver_Test extends Test_Case {
+
+	/**
+	 * The resolver instance.
+	 *
+	 * @var Ability_Function_Resolver
+	 */
+	private Ability_Function_Resolver $resolver;
+
+	/**
+	 * Sets up test fixtures.
+	 *
+	 * @return void
+	 */
+	protected function setUp(): void {
+		parent::setUp();
+		$this->resolver = new Ability_Function_Resolver();
+	}
+
+	/**
+	 * Checks if WordPress Abilities API is available.
+	 *
+	 * @return bool True if the Abilities API is available, false otherwise.
+	 */
+	private function is_abilities_api_available(): bool {
+		return function_exists( 'wp_register_ability' ) && function_exists( 'wp_get_ability' ) && class_exists( 'WP_Ability' );
+	}
+
+	/**
+	 * Tests is_ability_call returns true for valid ability calls.
+	 *
+	 * @return void
+	 */
+	public function test_is_ability_call_returns_true_for_valid_ability(): void {
+		$call = new FunctionCall( 'func_123', 'wpab__tec__create_event', array( 'title' => 'Test Event' ) );
+		$this->assertTrue( $this->resolver->is_ability_call( $call ) );
+	}
+
+	/**
+	 * Tests is_ability_call returns true for nested namespace abilities.
+	 *
+	 * @return void
+	 */
+	public function test_is_ability_call_returns_true_for_nested_namespace(): void {
+		$call = new FunctionCall( 'func_456', 'wpab__tec__v1__create_event', array() );
+		$this->assertTrue( $this->resolver->is_ability_call( $call ) );
+	}
+
+	/**
+	 * Tests is_ability_call returns false for non-ability calls.
+	 *
+	 * @return void
+	 */
+	public function test_is_ability_call_returns_false_for_non_ability(): void {
+		$call = new FunctionCall( 'func_789', 'regular_function', array() );
+		$this->assertFalse( $this->resolver->is_ability_call( $call ) );
+	}
+
+	/**
+	 * Tests is_ability_call returns false when function name is null.
+	 *
+	 * @return void
+	 */
+	public function test_is_ability_call_returns_false_when_name_is_null(): void {
+		$call = new FunctionCall( 'func_999', null, array() );
+		$this->assertFalse( $this->resolver->is_ability_call( $call ) );
+	}
+
+	/**
+	 * Tests is_ability_call returns false for partial prefix match.
+	 *
+	 * @return void
+	 */
+	public function test_is_ability_call_returns_false_for_partial_prefix(): void {
+		$call = new FunctionCall( 'func_111', 'wpab_single_underscore', array() );
+		$this->assertFalse( $this->resolver->is_ability_call( $call ) );
+	}
+
+	/**
+	 * Tests execute_ability returns error for non-ability call.
+	 *
+	 * @return void
+	 */
+	public function test_execute_ability_returns_error_for_non_ability_call(): void {
+		$call     = new FunctionCall( 'func_123', 'regular_function', array() );
+		$response = $this->resolver->execute_ability( $call );
+
+		$this->assertInstanceOf( FunctionResponse::class, $response );
+		$this->assertEquals( 'func_123', $response->getId() );
+		$this->assertEquals( 'regular_function', $response->getName() );
+
+		$result = $response->getResponse();
+		$this->assertIsArray( $result );
+		$this->assertArrayHasKey( 'error', $result );
+		$this->assertEquals( 'Not an ability function call', $result['error'] );
+		$this->assertEquals( 'invalid_ability_call', $result['code'] );
+	}
+
+	/**
+	 * Tests execute_ability returns error when ability not found.
+	 *
+	 * @return void
+	 */
+	public function test_execute_ability_returns_error_when_ability_not_found(): void {
+		if ( ! $this->is_abilities_api_available() ) {
+			$this->markTestSkipped( 'WordPress Abilities API is not available (requires WordPress 6.9+)' );
+		}
+
+		$call     = new FunctionCall( 'func_456', 'wpab__nonexistent__ability', array() );
+		$response = $this->resolver->execute_ability( $call );
+
+		$this->assertInstanceOf( FunctionResponse::class, $response );
+		$this->assertEquals( 'func_456', $response->getId() );
+		$this->assertEquals( 'wpab__nonexistent__ability', $response->getName() );
+
+		$result = $response->getResponse();
+		$this->assertIsArray( $result );
+		$this->assertArrayHasKey( 'error', $result );
+		$this->assertStringContainsString( 'not found', $result['error'] );
+		$this->assertEquals( 'ability_not_found', $result['code'] );
+	}
+
+	/**
+	 * Tests execute_ability with successful execution.
+	 *
+	 * @return void
+	 */
+	public function test_execute_ability_successful_execution(): void {
+		if ( ! $this->is_abilities_api_available() ) {
+			$this->markTestSkipped( 'WordPress Abilities API is not available (requires WordPress 6.9+)' );
+		}
+
+		// Register a test ability.
+		wp_register_ability(
+			'test/hello',
+			array(
+				'label'               => 'Test Hello Ability',
+				'description'         => 'Says hello',
+				'category'            => 'general',
+				'input_schema'        => array(
+					'type'       => 'object',
+					'properties' => array(
+						'name' => array( 'type' => 'string' ),
+					),
+				),
+				'output_schema'       => array(
+					'type'       => 'object',
+					'properties' => array(
+						'message' => array( 'type' => 'string' ),
+					),
+				),
+				'execute_callback'    => function ( $input ) {
+					return array( 'message' => 'Hello ' . $input['name'] );
+				},
+				'permission_callback' => '__return_true',
+			)
+		);
+
+		$call     = new FunctionCall( 'func_789', 'wpab__test__hello', array( 'name' => 'World' ) );
+		$response = $this->resolver->execute_ability( $call );
+
+		$this->assertInstanceOf( FunctionResponse::class, $response );
+		$this->assertEquals( 'func_789', $response->getId() );
+		$this->assertEquals( 'wpab__test__hello', $response->getName() );
+
+		$result = $response->getResponse();
+		$this->assertIsArray( $result );
+		$this->assertArrayHasKey( 'message', $result );
+		$this->assertEquals( 'Hello World', $result['message'] );
+	}
+
+	/**
+	 * Tests execute_ability with WP_Error response.
+	 *
+	 * @return void
+	 */
+	public function test_execute_ability_handles_wp_error(): void {
+		if ( ! $this->is_abilities_api_available() ) {
+			$this->markTestSkipped( 'WordPress Abilities API is not available (requires WordPress 6.9+)' );
+		}
+
+		// Register an ability that returns WP_Error.
+		wp_register_ability(
+			'test/error',
+			array(
+				'label'               => 'Test Error Ability',
+				'description'         => 'Returns an error',
+				'category'            => 'general',
+				'input_schema'        => array( 'type' => 'object' ),
+				'output_schema'       => array( 'type' => 'object' ),
+				'execute_callback'    => function () {
+					return new WP_Error( 'test_error', 'This is a test error', array( 'extra' => 'data' ) );
+				},
+				'permission_callback' => '__return_true',
+			)
+		);
+
+		$call     = new FunctionCall( 'func_999', 'wpab__test__error', array() );
+		$response = $this->resolver->execute_ability( $call );
+
+		$this->assertInstanceOf( FunctionResponse::class, $response );
+
+		$result = $response->getResponse();
+		$this->assertIsArray( $result );
+		$this->assertArrayHasKey( 'error', $result );
+		$this->assertEquals( 'This is a test error', $result['error'] );
+		$this->assertEquals( 'test_error', $result['code'] );
+		$this->assertArrayHasKey( 'data', $result );
+		$this->assertEquals( array( 'extra' => 'data' ), $result['data'] );
+	}
+
+	/**
+	 * Tests execute_ability with nested namespace.
+	 *
+	 * @return void
+	 */
+	public function test_execute_ability_with_nested_namespace(): void {
+		if ( ! $this->is_abilities_api_available() ) {
+			$this->markTestSkipped( 'WordPress Abilities API is not available (requires WordPress 6.9+)' );
+		}
+
+		// Register an ability with nested namespace.
+		wp_register_ability(
+			'test/v1/nested',
+			array(
+				'label'               => 'Test Nested Ability',
+				'description'         => 'Nested namespace test',
+				'category'            => 'general',
+				'input_schema'        => array( 'type' => 'object' ),
+				'output_schema'       => array(
+					'type'       => 'object',
+					'properties' => array(
+						'result' => array( 'type' => 'string' ),
+					),
+				),
+				'execute_callback'    => function () {
+					return array( 'result' => 'nested success' );
+				},
+				'permission_callback' => '__return_true',
+			)
+		);
+
+		$call     = new FunctionCall( 'func_nested', 'wpab__test__v1__nested', array() );
+		$response = $this->resolver->execute_ability( $call );
+
+		$this->assertInstanceOf( FunctionResponse::class, $response );
+
+		$result = $response->getResponse();
+		$this->assertIsArray( $result );
+		$this->assertEquals( 'nested success', $result['result'] );
+	}
+
+	/**
+	 * Tests execute_ability handles missing function ID.
+	 *
+	 * @return void
+	 */
+	public function test_execute_ability_handles_missing_id(): void {
+		if ( ! $this->is_abilities_api_available() ) {
+			$this->markTestSkipped( 'WordPress Abilities API is not available (requires WordPress 6.9+)' );
+		}
+
+		$call     = new FunctionCall( null, 'wpab__test__missing', array() );
+		$response = $this->resolver->execute_ability( $call );
+
+		$this->assertInstanceOf( FunctionResponse::class, $response );
+		$this->assertEquals( 'unknown', $response->getId() );
+	}
+
+	/**
+	 * Tests has_ability_calls returns true when message contains ability calls.
+	 *
+	 * @return void
+	 */
+	public function test_has_ability_calls_returns_true_when_present(): void {
+		$function_call = new FunctionCall( 'func_123', 'wpab__tec__create_event', array() );
+		$parts         = array(
+			new MessagePart( 'Some text' ),
+			new MessagePart( $function_call ),
+		);
+		$message       = new ModelMessage( $parts );
+
+		$this->assertTrue( $this->resolver->has_ability_calls( $message ) );
+	}
+
+	/**
+	 * Tests has_ability_calls returns false when no ability calls present.
+	 *
+	 * @return void
+	 */
+	public function test_has_ability_calls_returns_false_when_not_present(): void {
+		$function_call = new FunctionCall( 'func_456', 'regular_function', array() );
+		$parts         = array(
+			new MessagePart( 'Some text' ),
+			new MessagePart( $function_call ),
+		);
+		$message       = new ModelMessage( $parts );
+
+		$this->assertFalse( $this->resolver->has_ability_calls( $message ) );
+	}
+
+	/**
+	 * Tests has_ability_calls returns false for text-only message.
+	 *
+	 * @return void
+	 */
+	public function test_has_ability_calls_returns_false_for_text_only(): void {
+		$parts   = array( new MessagePart( 'Just text' ) );
+		$message = new UserMessage( $parts );
+
+		$this->assertFalse( $this->resolver->has_ability_calls( $message ) );
+	}
+
+	/**
+	 * Tests has_ability_calls returns true with mixed content.
+	 *
+	 * @return void
+	 */
+	public function test_has_ability_calls_returns_true_with_mixed_content(): void {
+		$regular_call = new FunctionCall( 'func_1', 'regular_function', array() );
+		$ability_call = new FunctionCall( 'func_2', 'wpab__test__ability', array() );
+		$parts        = array(
+			new MessagePart( 'Text' ),
+			new MessagePart( $regular_call ),
+			new MessagePart( $ability_call ),
+		);
+		$message      = new ModelMessage( $parts );
+
+		$this->assertTrue( $this->resolver->has_ability_calls( $message ) );
+	}
+
+	/**
+	 * Tests has_ability_calls with empty message.
+	 *
+	 * @return void
+	 */
+	public function test_has_ability_calls_with_empty_message(): void {
+		$message = new ModelMessage( array() );
+		$this->assertFalse( $this->resolver->has_ability_calls( $message ) );
+	}
+
+	/**
+	 * Tests execute_abilities processes all function calls.
+	 *
+	 * @return void
+	 */
+	public function test_execute_abilities_processes_all_calls(): void {
+		if ( ! $this->is_abilities_api_available() ) {
+			$this->markTestSkipped( 'WordPress Abilities API is not available (requires WordPress 6.9+)' );
+		}
+
+		// Register test abilities.
+		wp_register_ability(
+			'test/one',
+			array(
+				'label'               => 'Test One',
+				'description'         => 'First test',
+				'category'            => 'general',
+				'input_schema'        => array( 'type' => 'object' ),
+				'output_schema'       => array(
+					'type'       => 'object',
+					'properties' => array(
+						'value' => array( 'type' => 'string' ),
+					),
+				),
+				'execute_callback'    => function () {
+					return array( 'value' => 'one' );
+				},
+				'permission_callback' => '__return_true',
+			)
+		);
+
+		wp_register_ability(
+			'test/two',
+			array(
+				'label'               => 'Test Two',
+				'description'         => 'Second test',
+				'category'            => 'general',
+				'input_schema'        => array( 'type' => 'object' ),
+				'output_schema'       => array(
+					'type'       => 'object',
+					'properties' => array(
+						'value' => array( 'type' => 'string' ),
+					),
+				),
+				'execute_callback'    => function () {
+					return array( 'value' => 'two' );
+				},
+				'permission_callback' => '__return_true',
+			)
+		);
+
+		$call1   = new FunctionCall( 'func_1', 'wpab__test__one', array() );
+		$call2   = new FunctionCall( 'func_2', 'wpab__test__two', array() );
+		$parts   = array(
+			new MessagePart( $call1 ),
+			new MessagePart( $call2 ),
+		);
+		$message = new ModelMessage( $parts );
+
+		$result = $this->resolver->execute_abilities( $message );
+
+		$this->assertInstanceOf( Message::class, $result );
+		$this->assertTrue( $result->getRole()->isModel() );
+
+		$result_parts = $result->getParts();
+		$this->assertCount( 2, $result_parts );
+
+		$response1 = $result_parts[0]->getFunctionResponse();
+		$this->assertInstanceOf( FunctionResponse::class, $response1 );
+		$this->assertEquals( 'func_1', $response1->getId() );
+		$this->assertEquals( array( 'value' => 'one' ), $response1->getResponse() );
+
+		$response2 = $result_parts[1]->getFunctionResponse();
+		$this->assertInstanceOf( FunctionResponse::class, $response2 );
+		$this->assertEquals( 'func_2', $response2->getId() );
+		$this->assertEquals( array( 'value' => 'two' ), $response2->getResponse() );
+	}
+
+	/**
+	 * Tests execute_abilities returns ModelMessage.
+	 *
+	 * @return void
+	 */
+	public function test_execute_abilities_returns_model_message(): void {
+		if ( ! $this->is_abilities_api_available() ) {
+			$this->markTestSkipped( 'WordPress Abilities API is not available (requires WordPress 6.9+)' );
+		}
+
+		wp_register_ability(
+			'test/msg',
+			array(
+				'label'               => 'Test Message',
+				'description'         => 'Test',
+				'category'            => 'general',
+				'input_schema'        => array( 'type' => 'object' ),
+				'output_schema'       => array( 'type' => 'object' ),
+				'execute_callback'    => function () {
+					return array( 'ok' => true );
+				},
+				'permission_callback' => '__return_true',
+			)
+		);
+
+		$call    = new FunctionCall( 'func_1', 'wpab__test__msg', array() );
+		$parts   = array( new MessagePart( $call ) );
+		$message = new ModelMessage( $parts );
+
+		$result = $this->resolver->execute_abilities( $message );
+
+		$this->assertInstanceOf( ModelMessage::class, $result );
+	}
+
+	/**
+	 * Tests execute_abilities with empty message.
+	 *
+	 * @return void
+	 */
+	public function test_execute_abilities_with_empty_message(): void {
+		$message = new ModelMessage( array() );
+		$result  = $this->resolver->execute_abilities( $message );
+
+		$this->assertInstanceOf( Message::class, $result );
+		$this->assertCount( 0, $result->getParts() );
+	}
+
+	/**
+	 * Tests execute_abilities handles errors gracefully.
+	 *
+	 * @return void
+	 */
+	public function test_execute_abilities_handles_errors_gracefully(): void {
+		if ( ! $this->is_abilities_api_available() ) {
+			$this->markTestSkipped( 'WordPress Abilities API is not available (requires WordPress 6.9+)' );
+		}
+
+		$call    = new FunctionCall( 'func_1', 'wpab__nonexistent__ability', array() );
+		$parts   = array( new MessagePart( $call ) );
+		$message = new ModelMessage( $parts );
+
+		$result = $this->resolver->execute_abilities( $message );
+
+		$this->assertInstanceOf( Message::class, $result );
+
+		$result_parts = $result->getParts();
+		$this->assertCount( 1, $result_parts );
+
+		$response = $result_parts[0]->getFunctionResponse();
+		$this->assertInstanceOf( FunctionResponse::class, $response );
+
+		$response_data = $response->getResponse();
+		$this->assertArrayHasKey( 'error', $response_data );
+		$this->assertEquals( 'ability_not_found', $response_data['code'] );
+	}
+
+	/**
+	 * Tests execute_abilities with mixed content including non-function parts.
+	 *
+	 * @return void
+	 */
+	public function test_execute_abilities_with_mixed_content(): void {
+		if ( ! $this->is_abilities_api_available() ) {
+			$this->markTestSkipped( 'WordPress Abilities API is not available (requires WordPress 6.9+)' );
+		}
+
+		wp_register_ability(
+			'test/mixed',
+			array(
+				'label'               => 'Test Mixed',
+				'description'         => 'Mixed content test',
+				'category'            => 'general',
+				'input_schema'        => array( 'type' => 'object' ),
+				'output_schema'       => array( 'type' => 'object' ),
+				'execute_callback'    => function () {
+					return array( 'result' => 'mixed' );
+				},
+				'permission_callback' => '__return_true',
+			)
+		);
+
+		$call    = new FunctionCall( 'func_1', 'wpab__test__mixed', array() );
+		$parts   = array(
+			new MessagePart( 'Text before' ),
+			new MessagePart( $call ),
+			new MessagePart( 'Text after' ),
+		);
+		$message = new ModelMessage( $parts );
+
+		$result = $this->resolver->execute_abilities( $message );
+
+		// Only function calls are processed, not text parts.
+		$result_parts = $result->getParts();
+		$this->assertCount( 1, $result_parts );
+		$this->assertInstanceOf( FunctionResponse::class, $result_parts[0]->getFunctionResponse() );
+	}
+
+	/**
+	 * Tests namespace transformation: simple namespace.
+	 *
+	 * @return void
+	 */
+	public function test_namespace_transformation_simple(): void {
+		if ( ! $this->is_abilities_api_available() ) {
+			$this->markTestSkipped( 'WordPress Abilities API is not available (requires WordPress 6.9+)' );
+		}
+
+		wp_register_ability(
+			'plugin/action',
+			array(
+				'label'               => 'Test Action',
+				'description'         => 'Test namespace transformation',
+				'category'            => 'general',
+				'input_schema'        => array( 'type' => 'object' ),
+				'output_schema'       => array(
+					'type'       => 'object',
+					'properties' => array(
+						'namespace' => array( 'type' => 'string' ),
+					),
+				),
+				'execute_callback'    => function () {
+					return array( 'namespace' => 'plugin/action' );
+				},
+				'permission_callback' => '__return_true',
+			)
+		);
+
+		$call     = new FunctionCall( 'func_1', 'wpab__plugin__action', array() );
+		$response = $this->resolver->execute_ability( $call );
+
+		$result = $response->getResponse();
+		$this->assertEquals( 'plugin/action', $result['namespace'] );
+	}
+
+	/**
+	 * Tests namespace transformation: deeply nested namespace.
+	 *
+	 * @return void
+	 */
+	public function test_namespace_transformation_deeply_nested(): void {
+		if ( ! $this->is_abilities_api_available() ) {
+			$this->markTestSkipped( 'WordPress Abilities API is not available (requires WordPress 6.9+)' );
+		}
+
+		wp_register_ability(
+			'org/plugin/v2/feature/action',
+			array(
+				'label'               => 'Test Deeply Nested',
+				'description'         => 'Test deeply nested namespace',
+				'category'            => 'general',
+				'input_schema'        => array( 'type' => 'object' ),
+				'output_schema'       => array(
+					'type'       => 'object',
+					'properties' => array(
+						'depth' => array( 'type' => 'integer' ),
+					),
+				),
+				'execute_callback'    => function () {
+					return array( 'depth' => 5 );
+				},
+				'permission_callback' => '__return_true',
+			)
+		);
+
+		$call     = new FunctionCall( 'func_1', 'wpab__org__plugin__v2__feature__action', array() );
+		$response = $this->resolver->execute_ability( $call );
+
+		$result = $response->getResponse();
+		$this->assertEquals( 5, $result['depth'] );
+	}
+}

--- a/tests/phpunit/tests/Abilities/Ability_Function_Resolver_Tests.php
+++ b/tests/phpunit/tests/Abilities/Ability_Function_Resolver_Tests.php
@@ -19,11 +19,11 @@ use WordPress\AiClient\Tools\DTO\FunctionResponse;
 /**
  * Test class for Ability_Function_Resolver.
  *
- * Note: Tests that require actual ability registration are not included here
- * because WordPress 6.9 requires abilities to be registered during specific
- * hooks (wp_abilities_api_categories_init and wp_abilities_api_init) which
- * fire during WordPress bootstrap. Integration tests with registered abilities
- * would need to be set up via a bootstrap file.
+ * Test abilities are registered during bootstrap in tests/phpunit/bootstrap.php:
+ * - wpaiclienttests/simple: No parameters, returns { success: true }
+ * - wpaiclienttests/with-params: Accepts title parameter, returns { success: true, title: ... }
+ * - wpaiclienttests/returns-error: Always returns a WP_Error
+ * - wpaiclienttests/hyphen-test: Tests hyphenated names
  */
 class Ability_Function_Resolver_Test extends Test_Case {
 
@@ -345,5 +345,123 @@ class Ability_Function_Resolver_Test extends Test_Case {
 	public function test_ability_name_to_function_name_nested(): void {
 		$result = Ability_Function_Resolver::ability_name_to_function_name( 'tec/v1/create_event' );
 		$this->assertEquals( 'wpab__tec__v1__create_event', $result );
+	}
+
+	/**
+	 * Tests execute_ability successfully executes a registered ability.
+	 *
+	 * @return void
+	 */
+	public function test_execute_ability_success(): void {
+		$call     = new FunctionCall( 'func_123', 'wpab__wpaiclienttests__simple', array() );
+		$response = Ability_Function_Resolver::execute_ability( $call );
+
+		$this->assertInstanceOf( FunctionResponse::class, $response );
+		$this->assertEquals( 'func_123', $response->getId() );
+		$this->assertEquals( 'wpab__wpaiclienttests__simple', $response->getName() );
+
+		$result = $response->getResponse();
+		$this->assertIsArray( $result );
+		$this->assertArrayHasKey( 'success', $result );
+		$this->assertTrue( $result['success'] );
+	}
+
+	/**
+	 * Tests execute_ability passes parameters to ability.
+	 *
+	 * @return void
+	 */
+	public function test_execute_ability_with_parameters(): void {
+		$call     = new FunctionCall( 'func_456', 'wpab__wpaiclienttests__with-params', array( 'title' => 'Test Title' ) );
+		$response = Ability_Function_Resolver::execute_ability( $call );
+
+		$this->assertInstanceOf( FunctionResponse::class, $response );
+
+		$result = $response->getResponse();
+		$this->assertIsArray( $result );
+		$this->assertArrayHasKey( 'success', $result );
+		$this->assertTrue( $result['success'] );
+		$this->assertArrayHasKey( 'title', $result );
+		$this->assertEquals( 'Test Title', $result['title'] );
+	}
+
+	/**
+	 * Tests execute_ability handles WP_Error from ability.
+	 *
+	 * @return void
+	 */
+	public function test_execute_ability_handles_wp_error(): void {
+		$call     = new FunctionCall( 'func_789', 'wpab__wpaiclienttests__returns-error', array() );
+		$response = Ability_Function_Resolver::execute_ability( $call );
+
+		$this->assertInstanceOf( FunctionResponse::class, $response );
+		$this->assertEquals( 'func_789', $response->getId() );
+
+		$result = $response->getResponse();
+		$this->assertIsArray( $result );
+		$this->assertArrayHasKey( 'error', $result );
+		$this->assertEquals( 'This is a test error message.', $result['error'] );
+		$this->assertArrayHasKey( 'code', $result );
+		$this->assertEquals( 'test_error', $result['code'] );
+	}
+
+	/**
+	 * Tests execute_abilities successfully executes registered abilities.
+	 *
+	 * @return void
+	 */
+	public function test_execute_abilities_success(): void {
+		$call    = new FunctionCall( 'func_1', 'wpab__wpaiclienttests__simple', array() );
+		$parts   = array( new MessagePart( $call ) );
+		$message = new ModelMessage( $parts );
+
+		$result = Ability_Function_Resolver::execute_abilities( $message );
+
+		$this->assertInstanceOf( UserMessage::class, $result );
+
+		$result_parts = $result->getParts();
+		$this->assertCount( 1, $result_parts );
+
+		$response = $result_parts[0]->getFunctionResponse();
+		$this->assertInstanceOf( FunctionResponse::class, $response );
+
+		$response_data = $response->getResponse();
+		$this->assertArrayHasKey( 'success', $response_data );
+		$this->assertTrue( $response_data['success'] );
+	}
+
+	/**
+	 * Tests execute_abilities with multiple registered abilities.
+	 *
+	 * @return void
+	 */
+	public function test_execute_abilities_multiple_success(): void {
+		$call1   = new FunctionCall( 'func_1', 'wpab__wpaiclienttests__simple', array() );
+		$call2   = new FunctionCall( 'func_2', 'wpab__wpaiclienttests__with-params', array( 'title' => 'Test' ) );
+		$parts   = array(
+			new MessagePart( $call1 ),
+			new MessagePart( $call2 ),
+		);
+		$message = new ModelMessage( $parts );
+
+		$result = Ability_Function_Resolver::execute_abilities( $message );
+
+		$result_parts = $result->getParts();
+		$this->assertCount( 2, $result_parts );
+
+		// First ability response.
+		$response1 = $result_parts[0]->getFunctionResponse();
+		$this->assertInstanceOf( FunctionResponse::class, $response1 );
+		$this->assertEquals( 'func_1', $response1->getId() );
+		$response1_data = $response1->getResponse();
+		$this->assertTrue( $response1_data['success'] );
+
+		// Second ability response.
+		$response2 = $result_parts[1]->getFunctionResponse();
+		$this->assertInstanceOf( FunctionResponse::class, $response2 );
+		$this->assertEquals( 'func_2', $response2->getId() );
+		$response2_data = $response2->getResponse();
+		$this->assertTrue( $response2_data['success'] );
+		$this->assertEquals( 'Test', $response2_data['title'] );
 	}
 }

--- a/tests/phpunit/tests/Abilities/Ability_Function_Resolver_Tests.php
+++ b/tests/phpunit/tests/Abilities/Ability_Function_Resolver_Tests.php
@@ -28,30 +28,13 @@ use WordPress\AiClient\Tools\DTO\FunctionResponse;
 class Ability_Function_Resolver_Test extends Test_Case {
 
 	/**
-	 * The resolver instance.
-	 *
-	 * @var Ability_Function_Resolver
-	 */
-	private Ability_Function_Resolver $resolver;
-
-	/**
-	 * Sets up test fixtures.
-	 *
-	 * @return void
-	 */
-	protected function setUp(): void {
-		parent::setUp();
-		$this->resolver = new Ability_Function_Resolver();
-	}
-
-	/**
 	 * Tests is_ability_call returns true for valid ability calls.
 	 *
 	 * @return void
 	 */
 	public function test_is_ability_call_returns_true_for_valid_ability(): void {
 		$call = new FunctionCall( 'func_123', 'wpab__tec__create_event', array( 'title' => 'Test Event' ) );
-		$this->assertTrue( $this->resolver->is_ability_call( $call ) );
+		$this->assertTrue( Ability_Function_Resolver::is_ability_call( $call ) );
 	}
 
 	/**
@@ -61,7 +44,7 @@ class Ability_Function_Resolver_Test extends Test_Case {
 	 */
 	public function test_is_ability_call_returns_true_for_nested_namespace(): void {
 		$call = new FunctionCall( 'func_456', 'wpab__tec__v1__create_event', array() );
-		$this->assertTrue( $this->resolver->is_ability_call( $call ) );
+		$this->assertTrue( Ability_Function_Resolver::is_ability_call( $call ) );
 	}
 
 	/**
@@ -71,7 +54,7 @@ class Ability_Function_Resolver_Test extends Test_Case {
 	 */
 	public function test_is_ability_call_returns_false_for_non_ability(): void {
 		$call = new FunctionCall( 'func_789', 'regular_function', array() );
-		$this->assertFalse( $this->resolver->is_ability_call( $call ) );
+		$this->assertFalse( Ability_Function_Resolver::is_ability_call( $call ) );
 	}
 
 	/**
@@ -81,7 +64,7 @@ class Ability_Function_Resolver_Test extends Test_Case {
 	 */
 	public function test_is_ability_call_returns_false_when_name_is_null(): void {
 		$call = new FunctionCall( 'func_999', null, array() );
-		$this->assertFalse( $this->resolver->is_ability_call( $call ) );
+		$this->assertFalse( Ability_Function_Resolver::is_ability_call( $call ) );
 	}
 
 	/**
@@ -91,7 +74,7 @@ class Ability_Function_Resolver_Test extends Test_Case {
 	 */
 	public function test_is_ability_call_returns_false_for_partial_prefix(): void {
 		$call = new FunctionCall( 'func_111', 'wpab_single_underscore', array() );
-		$this->assertFalse( $this->resolver->is_ability_call( $call ) );
+		$this->assertFalse( Ability_Function_Resolver::is_ability_call( $call ) );
 	}
 
 	/**
@@ -101,7 +84,7 @@ class Ability_Function_Resolver_Test extends Test_Case {
 	 */
 	public function test_execute_ability_returns_error_for_non_ability_call(): void {
 		$call     = new FunctionCall( 'func_123', 'regular_function', array() );
-		$response = $this->resolver->execute_ability( $call );
+		$response = Ability_Function_Resolver::execute_ability( $call );
 
 		$this->assertInstanceOf( FunctionResponse::class, $response );
 		$this->assertEquals( 'func_123', $response->getId() );
@@ -124,7 +107,7 @@ class Ability_Function_Resolver_Test extends Test_Case {
 		$this->setExpectedIncorrectUsage( 'WP_Abilities_Registry::get_registered' );
 
 		$call     = new FunctionCall( 'func_456', 'wpab__nonexistent__ability', array() );
-		$response = $this->resolver->execute_ability( $call );
+		$response = Ability_Function_Resolver::execute_ability( $call );
 
 		$this->assertInstanceOf( FunctionResponse::class, $response );
 		$this->assertEquals( 'func_456', $response->getId() );
@@ -147,7 +130,7 @@ class Ability_Function_Resolver_Test extends Test_Case {
 		$this->setExpectedIncorrectUsage( 'WP_Abilities_Registry::get_registered' );
 
 		$call     = new FunctionCall( null, 'wpab__test__missing', array() );
-		$response = $this->resolver->execute_ability( $call );
+		$response = Ability_Function_Resolver::execute_ability( $call );
 
 		$this->assertInstanceOf( FunctionResponse::class, $response );
 		$this->assertEquals( 'unknown', $response->getId() );
@@ -166,7 +149,7 @@ class Ability_Function_Resolver_Test extends Test_Case {
 		);
 		$message       = new ModelMessage( $parts );
 
-		$this->assertTrue( $this->resolver->has_ability_calls( $message ) );
+		$this->assertTrue( Ability_Function_Resolver::has_ability_calls( $message ) );
 	}
 
 	/**
@@ -182,7 +165,7 @@ class Ability_Function_Resolver_Test extends Test_Case {
 		);
 		$message       = new ModelMessage( $parts );
 
-		$this->assertFalse( $this->resolver->has_ability_calls( $message ) );
+		$this->assertFalse( Ability_Function_Resolver::has_ability_calls( $message ) );
 	}
 
 	/**
@@ -194,7 +177,7 @@ class Ability_Function_Resolver_Test extends Test_Case {
 		$parts   = array( new MessagePart( 'Just text' ) );
 		$message = new UserMessage( $parts );
 
-		$this->assertFalse( $this->resolver->has_ability_calls( $message ) );
+		$this->assertFalse( Ability_Function_Resolver::has_ability_calls( $message ) );
 	}
 
 	/**
@@ -212,7 +195,7 @@ class Ability_Function_Resolver_Test extends Test_Case {
 		);
 		$message      = new ModelMessage( $parts );
 
-		$this->assertTrue( $this->resolver->has_ability_calls( $message ) );
+		$this->assertTrue( Ability_Function_Resolver::has_ability_calls( $message ) );
 	}
 
 	/**
@@ -222,7 +205,7 @@ class Ability_Function_Resolver_Test extends Test_Case {
 	 */
 	public function test_has_ability_calls_with_empty_message(): void {
 		$message = new ModelMessage( array() );
-		$this->assertFalse( $this->resolver->has_ability_calls( $message ) );
+		$this->assertFalse( Ability_Function_Resolver::has_ability_calls( $message ) );
 	}
 
 	/**
@@ -232,7 +215,7 @@ class Ability_Function_Resolver_Test extends Test_Case {
 	 */
 	public function test_execute_abilities_with_empty_message(): void {
 		$message = new ModelMessage( array() );
-		$result  = $this->resolver->execute_abilities( $message );
+		$result  = Ability_Function_Resolver::execute_abilities( $message );
 
 		$this->assertInstanceOf( Message::class, $result );
 		$this->assertCount( 0, $result->getParts() );
@@ -251,7 +234,7 @@ class Ability_Function_Resolver_Test extends Test_Case {
 		$parts   = array( new MessagePart( $call ) );
 		$message = new ModelMessage( $parts );
 
-		$result = $this->resolver->execute_abilities( $message );
+		$result = Ability_Function_Resolver::execute_abilities( $message );
 
 		$this->assertInstanceOf( Message::class, $result );
 		$this->assertInstanceOf( UserMessage::class, $result );
@@ -280,7 +263,7 @@ class Ability_Function_Resolver_Test extends Test_Case {
 		$parts   = array( new MessagePart( $call ) );
 		$message = new ModelMessage( $parts );
 
-		$result = $this->resolver->execute_abilities( $message );
+		$result = Ability_Function_Resolver::execute_abilities( $message );
 
 		$this->assertInstanceOf( UserMessage::class, $result );
 	}
@@ -302,7 +285,7 @@ class Ability_Function_Resolver_Test extends Test_Case {
 		);
 		$message = new ModelMessage( $parts );
 
-		$result = $this->resolver->execute_abilities( $message );
+		$result = Ability_Function_Resolver::execute_abilities( $message );
 
 		$this->assertInstanceOf( Message::class, $result );
 
@@ -336,11 +319,31 @@ class Ability_Function_Resolver_Test extends Test_Case {
 		);
 		$message = new ModelMessage( $parts );
 
-		$result = $this->resolver->execute_abilities( $message );
+		$result = Ability_Function_Resolver::execute_abilities( $message );
 
 		// Only function calls are processed, not text parts.
 		$result_parts = $result->getParts();
 		$this->assertCount( 1, $result_parts );
 		$this->assertInstanceOf( FunctionResponse::class, $result_parts[0]->getFunctionResponse() );
+	}
+
+	/**
+	 * Tests ability_name_to_function_name converts simple names.
+	 *
+	 * @return void
+	 */
+	public function test_ability_name_to_function_name_simple(): void {
+		$result = Ability_Function_Resolver::ability_name_to_function_name( 'tec/create_event' );
+		$this->assertEquals( 'wpab__tec__create_event', $result );
+	}
+
+	/**
+	 * Tests ability_name_to_function_name converts nested namespaces.
+	 *
+	 * @return void
+	 */
+	public function test_ability_name_to_function_name_nested(): void {
+		$result = Ability_Function_Resolver::ability_name_to_function_name( 'tec/v1/create_event' );
+		$this->assertEquals( 'wpab__tec__v1__create_event', $result );
 	}
 }

--- a/tests/phpunit/tests/Abilities/Ability_Function_Resolver_Tests.php
+++ b/tests/phpunit/tests/Abilities/Ability_Function_Resolver_Tests.php
@@ -13,14 +13,17 @@ use WordPress\AiClient\Messages\DTO\Message;
 use WordPress\AiClient\Messages\DTO\MessagePart;
 use WordPress\AiClient\Messages\DTO\ModelMessage;
 use WordPress\AiClient\Messages\DTO\UserMessage;
-use WordPress\AiClient\Messages\Enums\MessageRoleEnum;
 use WordPress\AiClient\Tools\DTO\FunctionCall;
 use WordPress\AiClient\Tools\DTO\FunctionResponse;
-use WP_Ability;
-use WP_Error;
 
 /**
  * Test class for Ability_Function_Resolver.
+ *
+ * Note: Tests that require actual ability registration are not included here
+ * because WordPress 6.9 requires abilities to be registered during specific
+ * hooks (wp_abilities_api_categories_init and wp_abilities_api_init) which
+ * fire during WordPress bootstrap. Integration tests with registered abilities
+ * would need to be set up via a bootstrap file.
  */
 class Ability_Function_Resolver_Test extends Test_Case {
 
@@ -39,15 +42,6 @@ class Ability_Function_Resolver_Test extends Test_Case {
 	protected function setUp(): void {
 		parent::setUp();
 		$this->resolver = new Ability_Function_Resolver();
-	}
-
-	/**
-	 * Checks if WordPress Abilities API is available.
-	 *
-	 * @return bool True if the Abilities API is available, false otherwise.
-	 */
-	private function is_abilities_api_available(): bool {
-		return function_exists( 'wp_register_ability' ) && function_exists( 'wp_get_ability' ) && class_exists( 'WP_Ability' );
 	}
 
 	/**
@@ -126,9 +120,8 @@ class Ability_Function_Resolver_Test extends Test_Case {
 	 * @return void
 	 */
 	public function test_execute_ability_returns_error_when_ability_not_found(): void {
-		if ( ! $this->is_abilities_api_available() ) {
-			$this->markTestSkipped( 'WordPress Abilities API is not available (requires WordPress 6.9+)' );
-		}
+		// WordPress 6.9 triggers an incorrect usage notice when ability is not found.
+		$this->setExpectedIncorrectUsage( 'WP_Abilities_Registry::get_registered' );
 
 		$call     = new FunctionCall( 'func_456', 'wpab__nonexistent__ability', array() );
 		$response = $this->resolver->execute_ability( $call );
@@ -145,144 +138,13 @@ class Ability_Function_Resolver_Test extends Test_Case {
 	}
 
 	/**
-	 * Tests execute_ability with successful execution.
-	 *
-	 * @return void
-	 */
-	public function test_execute_ability_successful_execution(): void {
-		if ( ! $this->is_abilities_api_available() ) {
-			$this->markTestSkipped( 'WordPress Abilities API is not available (requires WordPress 6.9+)' );
-		}
-
-		// Register a test ability.
-		wp_register_ability(
-			'test/hello',
-			array(
-				'label'               => 'Test Hello Ability',
-				'description'         => 'Says hello',
-				'category'            => 'general',
-				'input_schema'        => array(
-					'type'       => 'object',
-					'properties' => array(
-						'name' => array( 'type' => 'string' ),
-					),
-				),
-				'output_schema'       => array(
-					'type'       => 'object',
-					'properties' => array(
-						'message' => array( 'type' => 'string' ),
-					),
-				),
-				'execute_callback'    => function ( $input ) {
-					return array( 'message' => 'Hello ' . $input['name'] );
-				},
-				'permission_callback' => '__return_true',
-			)
-		);
-
-		$call     = new FunctionCall( 'func_789', 'wpab__test__hello', array( 'name' => 'World' ) );
-		$response = $this->resolver->execute_ability( $call );
-
-		$this->assertInstanceOf( FunctionResponse::class, $response );
-		$this->assertEquals( 'func_789', $response->getId() );
-		$this->assertEquals( 'wpab__test__hello', $response->getName() );
-
-		$result = $response->getResponse();
-		$this->assertIsArray( $result );
-		$this->assertArrayHasKey( 'message', $result );
-		$this->assertEquals( 'Hello World', $result['message'] );
-	}
-
-	/**
-	 * Tests execute_ability with WP_Error response.
-	 *
-	 * @return void
-	 */
-	public function test_execute_ability_handles_wp_error(): void {
-		if ( ! $this->is_abilities_api_available() ) {
-			$this->markTestSkipped( 'WordPress Abilities API is not available (requires WordPress 6.9+)' );
-		}
-
-		// Register an ability that returns WP_Error.
-		wp_register_ability(
-			'test/error',
-			array(
-				'label'               => 'Test Error Ability',
-				'description'         => 'Returns an error',
-				'category'            => 'general',
-				'input_schema'        => array( 'type' => 'object' ),
-				'output_schema'       => array( 'type' => 'object' ),
-				'execute_callback'    => function () {
-					return new WP_Error( 'test_error', 'This is a test error', array( 'extra' => 'data' ) );
-				},
-				'permission_callback' => '__return_true',
-			)
-		);
-
-		$call     = new FunctionCall( 'func_999', 'wpab__test__error', array() );
-		$response = $this->resolver->execute_ability( $call );
-
-		$this->assertInstanceOf( FunctionResponse::class, $response );
-
-		$result = $response->getResponse();
-		$this->assertIsArray( $result );
-		$this->assertArrayHasKey( 'error', $result );
-		$this->assertEquals( 'This is a test error', $result['error'] );
-		$this->assertEquals( 'test_error', $result['code'] );
-		$this->assertArrayHasKey( 'data', $result );
-		$this->assertEquals( array( 'extra' => 'data' ), $result['data'] );
-	}
-
-	/**
-	 * Tests execute_ability with nested namespace.
-	 *
-	 * @return void
-	 */
-	public function test_execute_ability_with_nested_namespace(): void {
-		if ( ! $this->is_abilities_api_available() ) {
-			$this->markTestSkipped( 'WordPress Abilities API is not available (requires WordPress 6.9+)' );
-		}
-
-		// Register an ability with nested namespace.
-		wp_register_ability(
-			'test/v1/nested',
-			array(
-				'label'               => 'Test Nested Ability',
-				'description'         => 'Nested namespace test',
-				'category'            => 'general',
-				'input_schema'        => array( 'type' => 'object' ),
-				'output_schema'       => array(
-					'type'       => 'object',
-					'properties' => array(
-						'result' => array( 'type' => 'string' ),
-					),
-				),
-				'execute_callback'    => function () {
-					return array( 'result' => 'nested success' );
-				},
-				'permission_callback' => '__return_true',
-			)
-		);
-
-		$call     = new FunctionCall( 'func_nested', 'wpab__test__v1__nested', array() );
-		$response = $this->resolver->execute_ability( $call );
-
-		$this->assertInstanceOf( FunctionResponse::class, $response );
-
-		$result = $response->getResponse();
-		$this->assertIsArray( $result );
-		$this->assertEquals( 'nested success', $result['result'] );
-	}
-
-	/**
 	 * Tests execute_ability handles missing function ID.
 	 *
 	 * @return void
 	 */
 	public function test_execute_ability_handles_missing_id(): void {
-		if ( ! $this->is_abilities_api_available() ) {
-			$this->markTestSkipped( 'WordPress Abilities API is not available (requires WordPress 6.9+)' );
-		}
+		// WordPress 6.9 triggers an incorrect usage notice when ability is not found.
+		$this->setExpectedIncorrectUsage( 'WP_Abilities_Registry::get_registered' );
 
 		$call     = new FunctionCall( null, 'wpab__test__missing', array() );
 		$response = $this->resolver->execute_ability( $call );
@@ -364,118 +226,6 @@ class Ability_Function_Resolver_Test extends Test_Case {
 	}
 
 	/**
-	 * Tests execute_abilities processes all function calls.
-	 *
-	 * @return void
-	 */
-	public function test_execute_abilities_processes_all_calls(): void {
-		if ( ! $this->is_abilities_api_available() ) {
-			$this->markTestSkipped( 'WordPress Abilities API is not available (requires WordPress 6.9+)' );
-		}
-
-		// Register test abilities.
-		wp_register_ability(
-			'test/one',
-			array(
-				'label'               => 'Test One',
-				'description'         => 'First test',
-				'category'            => 'general',
-				'input_schema'        => array( 'type' => 'object' ),
-				'output_schema'       => array(
-					'type'       => 'object',
-					'properties' => array(
-						'value' => array( 'type' => 'string' ),
-					),
-				),
-				'execute_callback'    => function () {
-					return array( 'value' => 'one' );
-				},
-				'permission_callback' => '__return_true',
-			)
-		);
-
-		wp_register_ability(
-			'test/two',
-			array(
-				'label'               => 'Test Two',
-				'description'         => 'Second test',
-				'category'            => 'general',
-				'input_schema'        => array( 'type' => 'object' ),
-				'output_schema'       => array(
-					'type'       => 'object',
-					'properties' => array(
-						'value' => array( 'type' => 'string' ),
-					),
-				),
-				'execute_callback'    => function () {
-					return array( 'value' => 'two' );
-				},
-				'permission_callback' => '__return_true',
-			)
-		);
-
-		$call1   = new FunctionCall( 'func_1', 'wpab__test__one', array() );
-		$call2   = new FunctionCall( 'func_2', 'wpab__test__two', array() );
-		$parts   = array(
-			new MessagePart( $call1 ),
-			new MessagePart( $call2 ),
-		);
-		$message = new ModelMessage( $parts );
-
-		$result = $this->resolver->execute_abilities( $message );
-
-		$this->assertInstanceOf( Message::class, $result );
-		$this->assertTrue( $result->getRole()->isModel() );
-
-		$result_parts = $result->getParts();
-		$this->assertCount( 2, $result_parts );
-
-		$response1 = $result_parts[0]->getFunctionResponse();
-		$this->assertInstanceOf( FunctionResponse::class, $response1 );
-		$this->assertEquals( 'func_1', $response1->getId() );
-		$this->assertEquals( array( 'value' => 'one' ), $response1->getResponse() );
-
-		$response2 = $result_parts[1]->getFunctionResponse();
-		$this->assertInstanceOf( FunctionResponse::class, $response2 );
-		$this->assertEquals( 'func_2', $response2->getId() );
-		$this->assertEquals( array( 'value' => 'two' ), $response2->getResponse() );
-	}
-
-	/**
-	 * Tests execute_abilities returns ModelMessage.
-	 *
-	 * @return void
-	 */
-	public function test_execute_abilities_returns_model_message(): void {
-		if ( ! $this->is_abilities_api_available() ) {
-			$this->markTestSkipped( 'WordPress Abilities API is not available (requires WordPress 6.9+)' );
-		}
-
-		wp_register_ability(
-			'test/msg',
-			array(
-				'label'               => 'Test Message',
-				'description'         => 'Test',
-				'category'            => 'general',
-				'input_schema'        => array( 'type' => 'object' ),
-				'output_schema'       => array( 'type' => 'object' ),
-				'execute_callback'    => function () {
-					return array( 'ok' => true );
-				},
-				'permission_callback' => '__return_true',
-			)
-		);
-
-		$call    = new FunctionCall( 'func_1', 'wpab__test__msg', array() );
-		$parts   = array( new MessagePart( $call ) );
-		$message = new ModelMessage( $parts );
-
-		$result = $this->resolver->execute_abilities( $message );
-
-		$this->assertInstanceOf( ModelMessage::class, $result );
-	}
-
-	/**
 	 * Tests execute_abilities with empty message.
 	 *
 	 * @return void
@@ -489,14 +239,13 @@ class Ability_Function_Resolver_Test extends Test_Case {
 	}
 
 	/**
-	 * Tests execute_abilities handles errors gracefully.
+	 * Tests execute_abilities handles errors gracefully when ability not found.
 	 *
 	 * @return void
 	 */
 	public function test_execute_abilities_handles_errors_gracefully(): void {
-		if ( ! $this->is_abilities_api_available() ) {
-			$this->markTestSkipped( 'WordPress Abilities API is not available (requires WordPress 6.9+)' );
-		}
+		// WordPress 6.9 triggers an incorrect usage notice when ability is not found.
+		$this->setExpectedIncorrectUsage( 'WP_Abilities_Registry::get_registered' );
 
 		$call    = new FunctionCall( 'func_1', 'wpab__nonexistent__ability', array() );
 		$parts   = array( new MessagePart( $call ) );
@@ -505,6 +254,7 @@ class Ability_Function_Resolver_Test extends Test_Case {
 		$result = $this->resolver->execute_abilities( $message );
 
 		$this->assertInstanceOf( Message::class, $result );
+		$this->assertInstanceOf( UserMessage::class, $result );
 
 		$result_parts = $result->getParts();
 		$this->assertCount( 1, $result_parts );
@@ -518,31 +268,67 @@ class Ability_Function_Resolver_Test extends Test_Case {
 	}
 
 	/**
-	 * Tests execute_abilities with mixed content including non-function parts.
+	 * Tests execute_abilities returns UserMessage.
 	 *
 	 * @return void
 	 */
-	public function test_execute_abilities_with_mixed_content(): void {
-		if ( ! $this->is_abilities_api_available() ) {
-			$this->markTestSkipped( 'WordPress Abilities API is not available (requires WordPress 6.9+)' );
-		}
+	public function test_execute_abilities_returns_user_message(): void {
+		// WordPress 6.9 triggers an incorrect usage notice when ability is not found.
+		$this->setExpectedIncorrectUsage( 'WP_Abilities_Registry::get_registered' );
 
-		wp_register_ability(
-			'test/mixed',
-			array(
-				'label'               => 'Test Mixed',
-				'description'         => 'Mixed content test',
-				'category'            => 'general',
-				'input_schema'        => array( 'type' => 'object' ),
-				'output_schema'       => array( 'type' => 'object' ),
-				'execute_callback'    => function () {
-					return array( 'result' => 'mixed' );
-				},
-				'permission_callback' => '__return_true',
-			)
+		$call    = new FunctionCall( 'func_1', 'wpab__test__ability', array() );
+		$parts   = array( new MessagePart( $call ) );
+		$message = new ModelMessage( $parts );
+
+		$result = $this->resolver->execute_abilities( $message );
+
+		$this->assertInstanceOf( UserMessage::class, $result );
+	}
+
+	/**
+	 * Tests execute_abilities processes multiple function calls.
+	 *
+	 * @return void
+	 */
+	public function test_execute_abilities_processes_multiple_calls(): void {
+		// WordPress 6.9 triggers incorrect usage notices for each ability not found.
+		$this->setExpectedIncorrectUsage( 'WP_Abilities_Registry::get_registered' );
+
+		$call1   = new FunctionCall( 'func_1', 'wpab__test__one', array() );
+		$call2   = new FunctionCall( 'func_2', 'wpab__test__two', array() );
+		$parts   = array(
+			new MessagePart( $call1 ),
+			new MessagePart( $call2 ),
 		);
+		$message = new ModelMessage( $parts );
 
-		$call    = new FunctionCall( 'func_1', 'wpab__test__mixed', array() );
+		$result = $this->resolver->execute_abilities( $message );
+
+		$this->assertInstanceOf( Message::class, $result );
+
+		$result_parts = $result->getParts();
+		$this->assertCount( 2, $result_parts );
+
+		// Both should be FunctionResponse objects (with errors since abilities aren't registered).
+		$response1 = $result_parts[0]->getFunctionResponse();
+		$this->assertInstanceOf( FunctionResponse::class, $response1 );
+		$this->assertEquals( 'func_1', $response1->getId() );
+
+		$response2 = $result_parts[1]->getFunctionResponse();
+		$this->assertInstanceOf( FunctionResponse::class, $response2 );
+		$this->assertEquals( 'func_2', $response2->getId() );
+	}
+
+	/**
+	 * Tests execute_abilities only processes function call parts.
+	 *
+	 * @return void
+	 */
+	public function test_execute_abilities_only_processes_function_calls(): void {
+		// WordPress 6.9 triggers an incorrect usage notice when ability is not found.
+		$this->setExpectedIncorrectUsage( 'WP_Abilities_Registry::get_registered' );
+
+		$call    = new FunctionCall( 'func_1', 'wpab__test__ability', array() );
 		$parts   = array(
 			new MessagePart( 'Text before' ),
 			new MessagePart( $call ),
@@ -556,79 +342,5 @@ class Ability_Function_Resolver_Test extends Test_Case {
 		$result_parts = $result->getParts();
 		$this->assertCount( 1, $result_parts );
 		$this->assertInstanceOf( FunctionResponse::class, $result_parts[0]->getFunctionResponse() );
-	}
-
-	/**
-	 * Tests namespace transformation: simple namespace.
-	 *
-	 * @return void
-	 */
-	public function test_namespace_transformation_simple(): void {
-		if ( ! $this->is_abilities_api_available() ) {
-			$this->markTestSkipped( 'WordPress Abilities API is not available (requires WordPress 6.9+)' );
-		}
-
-		wp_register_ability(
-			'plugin/action',
-			array(
-				'label'               => 'Test Action',
-				'description'         => 'Test namespace transformation',
-				'category'            => 'general',
-				'input_schema'        => array( 'type' => 'object' ),
-				'output_schema'       => array(
-					'type'       => 'object',
-					'properties' => array(
-						'namespace' => array( 'type' => 'string' ),
-					),
-				),
-				'execute_callback'    => function () {
-					return array( 'namespace' => 'plugin/action' );
-				},
-				'permission_callback' => '__return_true',
-			)
-		);
-
-		$call     = new FunctionCall( 'func_1', 'wpab__plugin__action', array() );
-		$response = $this->resolver->execute_ability( $call );
-
-		$result = $response->getResponse();
-		$this->assertEquals( 'plugin/action', $result['namespace'] );
-	}
-
-	/**
-	 * Tests namespace transformation: deeply nested namespace.
-	 *
-	 * @return void
-	 */
-	public function test_namespace_transformation_deeply_nested(): void {
-		if ( ! $this->is_abilities_api_available() ) {
-			$this->markTestSkipped( 'WordPress Abilities API is not available (requires WordPress 6.9+)' );
-		}
-
-		wp_register_ability(
-			'org/plugin/v2/feature/action',
-			array(
-				'label'               => 'Test Deeply Nested',
-				'description'         => 'Test deeply nested namespace',
-				'category'            => 'general',
-				'input_schema'        => array( 'type' => 'object' ),
-				'output_schema'       => array(
-					'type'       => 'object',
-					'properties' => array(
-						'depth' => array( 'type' => 'integer' ),
-					),
-				),
-				'execute_callback'    => function () {
-					return array( 'depth' => 5 );
-				},
-				'permission_callback' => '__return_true',
-			)
-		);
-
-		$call     = new FunctionCall( 'func_1', 'wpab__org__plugin__v2__feature__action', array() );
-		$response = $this->resolver->execute_ability( $call );
-
-		$result = $response->getResponse();
-		$this->assertEquals( 5, $result['depth'] );
 	}
 }

--- a/tests/phpunit/tests/Builders/Prompt_Builder_Tests.php
+++ b/tests/phpunit/tests/Builders/Prompt_Builder_Tests.php
@@ -2021,4 +2021,198 @@ class PromptBuilderTest extends Test_Case {
 		$this->assertSame( $files[1], $speech_files[1] );
 		$this->assertSame( $files[2], $speech_files[2] );
 	}
+
+	/**
+	 * Gets the function declarations from the builder's model config.
+	 *
+	 * @param Prompt_Builder $builder The builder to get declarations from.
+	 * @return list<FunctionDeclaration>|null The function declarations or null if not set.
+	 */
+	private function get_function_declarations( Prompt_Builder $builder ): ?array {
+		/** @var ModelConfig $config */
+		$config = $this->get_wrapped_prompt_builder_property_value( $builder, 'modelConfig' );
+		return $config->getFunctionDeclarations();
+	}
+
+	/**
+	 * Tests using_ability with ability name string.
+	 *
+	 * @return void
+	 */
+	public function test_using_ability_with_string(): void {
+		$builder = new Prompt_Builder( $this->registry );
+		$result  = $builder->using_ability( 'wpaiclienttests/simple' );
+
+		$this->assertSame( $builder, $result );
+
+		$declarations = $this->get_function_declarations( $builder );
+
+		$this->assertNotNull( $declarations );
+		$this->assertCount( 1, $declarations );
+		$this->assertEquals( 'wpab__wpaiclienttests__simple', $declarations[0]->getName() );
+		$this->assertEquals( 'A simple test ability with no parameters.', $declarations[0]->getDescription() );
+	}
+
+	/**
+	 * Tests using_ability with WP_Ability object.
+	 *
+	 * @return void
+	 */
+	public function test_using_ability_with_wp_ability_object(): void {
+		$ability = wp_get_ability( 'wpaiclienttests/with-params' );
+
+		$builder = new Prompt_Builder( $this->registry );
+		$result  = $builder->using_ability( $ability );
+
+		$this->assertSame( $builder, $result );
+
+		$declarations = $this->get_function_declarations( $builder );
+
+		$this->assertNotNull( $declarations );
+		$this->assertCount( 1, $declarations );
+		$this->assertEquals( 'wpab__wpaiclienttests__with-params', $declarations[0]->getName() );
+		$this->assertEquals( 'A test ability that accepts parameters.', $declarations[0]->getDescription() );
+
+		// Verify input schema is passed through.
+		$params = $declarations[0]->getParameters();
+		$this->assertNotNull( $params );
+		$this->assertArrayHasKey( 'properties', $params );
+		$this->assertArrayHasKey( 'title', $params['properties'] );
+	}
+
+	/**
+	 * Tests using_ability with multiple abilities.
+	 *
+	 * @return void
+	 */
+	public function test_using_ability_with_multiple_abilities(): void {
+		$builder = new Prompt_Builder( $this->registry );
+		$result  = $builder->using_ability(
+			'wpaiclienttests/simple',
+			'wpaiclienttests/with-params',
+			'wpaiclienttests/returns-error'
+		);
+
+		$this->assertSame( $builder, $result );
+
+		$declarations = $this->get_function_declarations( $builder );
+
+		$this->assertNotNull( $declarations );
+		$this->assertCount( 3, $declarations );
+		$this->assertEquals( 'wpab__wpaiclienttests__simple', $declarations[0]->getName() );
+		$this->assertEquals( 'wpab__wpaiclienttests__with-params', $declarations[1]->getName() );
+		$this->assertEquals( 'wpab__wpaiclienttests__returns-error', $declarations[2]->getName() );
+	}
+
+	/**
+	 * Tests using_ability skips non-existent abilities.
+	 *
+	 * @return void
+	 */
+	public function test_using_ability_skips_nonexistent_abilities(): void {
+		$this->setExpectedIncorrectUsage( 'WP_Abilities_Registry::get_registered' );
+
+		$builder = new Prompt_Builder( $this->registry );
+		$result  = $builder->using_ability(
+			'wpaiclienttests/simple',
+			'nonexistent/ability',
+			'wpaiclienttests/with-params'
+		);
+
+		$this->assertSame( $builder, $result );
+
+		$declarations = $this->get_function_declarations( $builder );
+
+		// Only 2 valid abilities should be registered.
+		$this->assertNotNull( $declarations );
+		$this->assertCount( 2, $declarations );
+		$this->assertEquals( 'wpab__wpaiclienttests__simple', $declarations[0]->getName() );
+		$this->assertEquals( 'wpab__wpaiclienttests__with-params', $declarations[1]->getName() );
+	}
+
+	/**
+	 * Tests using_ability with empty arguments returns self.
+	 *
+	 * @return void
+	 */
+	public function test_using_ability_with_no_arguments_returns_self(): void {
+		$builder = new Prompt_Builder( $this->registry );
+		$result  = $builder->using_ability();
+
+		$this->assertSame( $builder, $result );
+
+		$declarations = $this->get_function_declarations( $builder );
+
+		$this->assertNull( $declarations );
+	}
+
+	/**
+	 * Tests using_ability with mixed strings and WP_Ability objects.
+	 *
+	 * @return void
+	 */
+	public function test_using_ability_with_mixed_types(): void {
+		$ability = wp_get_ability( 'wpaiclienttests/with-params' );
+
+		$builder = new Prompt_Builder( $this->registry );
+		$result  = $builder->using_ability(
+			'wpaiclienttests/simple',
+			$ability
+		);
+
+		$this->assertSame( $builder, $result );
+
+		$declarations = $this->get_function_declarations( $builder );
+
+		$this->assertNotNull( $declarations );
+		$this->assertCount( 2, $declarations );
+		$this->assertEquals( 'wpab__wpaiclienttests__simple', $declarations[0]->getName() );
+		$this->assertEquals( 'wpab__wpaiclienttests__with-params', $declarations[1]->getName() );
+	}
+
+	/**
+	 * Tests using_ability with hyphenated ability name.
+	 *
+	 * @return void
+	 */
+	public function test_using_ability_with_hyphenated_name(): void {
+		$builder = new Prompt_Builder( $this->registry );
+		$result  = $builder->using_ability( 'wpaiclienttests/hyphen-test' );
+
+		$this->assertSame( $builder, $result );
+
+		$declarations = $this->get_function_declarations( $builder );
+
+		$this->assertNotNull( $declarations );
+		$this->assertCount( 1, $declarations );
+		$this->assertEquals( 'wpab__wpaiclienttests__hyphen-test', $declarations[0]->getName() );
+	}
+
+	/**
+	 * Tests using_ability can be chained with other methods.
+	 *
+	 * @return void
+	 */
+	public function test_using_ability_method_chaining(): void {
+		$builder = new Prompt_Builder( $this->registry );
+		$result  = $builder
+			->with_text( 'Test prompt' )
+			->using_ability( 'wpaiclienttests/simple' )
+			->using_system_instruction( 'You are a helpful assistant' )
+			->using_max_tokens( 500 );
+
+		$this->assertSame( $builder, $result );
+
+		$declarations = $this->get_function_declarations( $builder );
+
+		$this->assertNotNull( $declarations );
+		$this->assertCount( 1, $declarations );
+		$this->assertEquals( 'wpab__wpaiclienttests__simple', $declarations[0]->getName() );
+
+		/** @var ModelConfig $config */
+		$config = $this->get_wrapped_prompt_builder_property_value( $builder, 'modelConfig' );
+
+		$this->assertEquals( 'You are a helpful assistant', $config->getSystemInstruction() );
+		$this->assertEquals( 500, $config->getMaxTokens() );
+	}
 }


### PR DESCRIPTION
This adds support for passing Abilities to the `Prompt_Builder` with `Prompt_Builder::using_ability()`. There are a couple interesting details to point out:

**What does the Ability turn into?**
The passed abilities are transformed into `FunctionDeclaration` instances and sent with the prompt.

**Translating Ability names**
Abilities use a naming convention that doesn't work well with function declarations, namely the forward-slashes. The function declaration name is therefore derived from the ability name in a bi-directional manner. A prefix for identifying that it is an ability is also added.
* Before: `namespace/v1/ability`
* After: `wpab__namespace__v1__ability`

**How are function calls handled?**
At this point, when the AI returns a `FunctionCall` it is not automatically resolved. The implementing developer can use the `Ability_Function_Resolver::is_ability_call()` or `Ability_Function_Resolver::has_ability_calls` methods to check if a `FunctionCall` is for an ability or a `Message` contains function calls tied to abilities, respectively. These are identified by checking for a `wpab__` prefix on the function call name. (Note: I thought about checking if the ability is registered, too, but decided against it as I think this means the AI is doing something wrong and should be handled another way.)

The developer can then use the `::execute_ability()` or `::execute_abilities()` methods to generate a `FunctionResponse` (or array thereof) to pass back with the following prompt.