### PR TITLE
Renames `using_ability` to `using_abilities`

### DIFF
--- a/includes/Builders/Prompt_Builder.php
+++ b/includes/Builders/Prompt_Builder.php
@@ -139,8 +139,8 @@ class Prompt_Builder {
 	 * Converts each WP_Ability to a FunctionDeclaration using the wpab__ prefix
 	 * naming convention and passes them to the underlying prompt builder.
 	 *
-	 * @since 0.2.1 Renamed from `using_ability` to `using_abilities`.
 	 * @since 0.2.0
+	 * @since 0.2.1 Renamed from `using_ability` to `using_abilities`.
 	 *
 	 * @param WP_Ability|string ...$abilities The abilities to register, either as WP_Ability objects or ability name strings.
 	 * @return self The current instance for method chaining.

--- a/includes/Builders/Prompt_Builder.php
+++ b/includes/Builders/Prompt_Builder.php
@@ -139,6 +139,7 @@ class Prompt_Builder {
 	 * Converts each WP_Ability to a FunctionDeclaration using the wpab__ prefix
 	 * naming convention and passes them to the underlying prompt builder.
 	 *
+	 * @since 0.2.1 Renamed from `using_ability` to `using_abilities`.
 	 * @since 0.2.0
 	 *
 	 * @param WP_Ability|string ...$abilities The abilities to register, either as WP_Ability objects or ability name strings.

--- a/includes/Builders/Prompt_Builder.php
+++ b/includes/Builders/Prompt_Builder.php
@@ -144,7 +144,7 @@ class Prompt_Builder {
 	 * @param WP_Ability|string ...$abilities The abilities to register, either as WP_Ability objects or ability name strings.
 	 * @return self The current instance for method chaining.
 	 */
-	public function using_ability( ...$abilities ): self {
+	public function using_abilities( ...$abilities ): self {
 		$declarations = array();
 
 		foreach ( $abilities as $ability ) {

--- a/tests/phpunit/tests/Builders/Prompt_Builder_Tests.php
+++ b/tests/phpunit/tests/Builders/Prompt_Builder_Tests.php
@@ -2075,7 +2075,7 @@ class Prompt_Builder_Tests extends Test_Case {
 	 */
 	public function test_using_ability_with_string(): void {
 		$builder = new Prompt_Builder( $this->registry );
-		$result  = $builder->using_ability( 'wpaiclienttests/simple' );
+		$result  = $builder->using_abilities( 'wpaiclienttests/simple' );
 
 		$this->assertSame( $builder, $result );
 
@@ -2096,7 +2096,7 @@ class Prompt_Builder_Tests extends Test_Case {
 		$ability = wp_get_ability( 'wpaiclienttests/with-params' );
 
 		$builder = new Prompt_Builder( $this->registry );
-		$result  = $builder->using_ability( $ability );
+		$result  = $builder->using_abilities( $ability );
 
 		$this->assertSame( $builder, $result );
 
@@ -2121,7 +2121,7 @@ class Prompt_Builder_Tests extends Test_Case {
 	 */
 	public function test_using_ability_with_multiple_abilities(): void {
 		$builder = new Prompt_Builder( $this->registry );
-		$result  = $builder->using_ability(
+		$result  = $builder->using_abilities(
 			'wpaiclienttests/simple',
 			'wpaiclienttests/with-params',
 			'wpaiclienttests/returns-error'
@@ -2147,7 +2147,7 @@ class Prompt_Builder_Tests extends Test_Case {
 		$this->setExpectedIncorrectUsage( 'WP_Abilities_Registry::get_registered' );
 
 		$builder = new Prompt_Builder( $this->registry );
-		$result  = $builder->using_ability(
+		$result  = $builder->using_abilities(
 			'wpaiclienttests/simple',
 			'nonexistent/ability',
 			'wpaiclienttests/with-params'
@@ -2171,7 +2171,7 @@ class Prompt_Builder_Tests extends Test_Case {
 	 */
 	public function test_using_ability_with_no_arguments_returns_self(): void {
 		$builder = new Prompt_Builder( $this->registry );
-		$result  = $builder->using_ability();
+		$result  = $builder->using_abilities();
 
 		$this->assertSame( $builder, $result );
 
@@ -2189,7 +2189,7 @@ class Prompt_Builder_Tests extends Test_Case {
 		$ability = wp_get_ability( 'wpaiclienttests/with-params' );
 
 		$builder = new Prompt_Builder( $this->registry );
-		$result  = $builder->using_ability(
+		$result  = $builder->using_abilities(
 			'wpaiclienttests/simple',
 			$ability
 		);
@@ -2211,7 +2211,7 @@ class Prompt_Builder_Tests extends Test_Case {
 	 */
 	public function test_using_ability_with_hyphenated_name(): void {
 		$builder = new Prompt_Builder( $this->registry );
-		$result  = $builder->using_ability( 'wpaiclienttests/hyphen-test' );
+		$result  = $builder->using_abilities( 'wpaiclienttests/hyphen-test' );
 
 		$this->assertSame( $builder, $result );
 
@@ -2231,7 +2231,7 @@ class Prompt_Builder_Tests extends Test_Case {
 		$builder = new Prompt_Builder( $this->registry );
 		$result  = $builder
 			->with_text( 'Test prompt' )
-			->using_ability( 'wpaiclienttests/simple' )
+			->using_abilities( 'wpaiclienttests/simple' )
 			->using_system_instruction( 'You are a helpful assistant' )
 			->using_max_tokens( 500 );
 


### PR DESCRIPTION
This tiny PR renames `Prompt_Builder::using_ability()` to `Prompt_Builder::using_abilities()` to be consistent with the plural naming convention for other variadic methods.