### PR TITLE
Update `php-ai-client` to 0.4 and provide relevant WordPress PSR implementations

### DIFF
--- a/composer.json
+++ b/composer.json
@@ -67,6 +67,6 @@
         ],
         "phpcs": "phpcs",
         "phpcbf": "phpcbf",
-        "phpstan": "phpstan analyze --memory-limit=512M"
+        "phpstan": "phpstan analyze --memory-limit=1024M"
     }
 }

--- a/composer.json
+++ b/composer.json
@@ -36,7 +36,7 @@
         "php": ">=7.4",
         "ext-json": "*",
         "nyholm/psr7": "^1.5",
-        "wordpress/php-ai-client": "^0.3"
+        "wordpress/php-ai-client": "^0.4"
     },
     "require-dev": {
         "automattic/vipwpcs": "^3.0",

--- a/composer.lock
+++ b/composer.lock
@@ -4,7 +4,7 @@
         "Read more about it at https://getcomposer.org/doc/01-basic-usage.md#installing-dependencies",
         "This file is @generated automatically"
     ],
-    "content-hash": "8bab82f741c54eb5e566a550875ee47c",
+    "content-hash": "a32cee75aedab7a3026000216d4eedfd",
     "packages": [
         {
             "name": "nyholm/psr7",
@@ -328,6 +328,56 @@
             "time": "2024-03-15T13:55:21+00:00"
         },
         {
+            "name": "psr/event-dispatcher",
+            "version": "1.0.0",
+            "source": {
+                "type": "git",
+                "url": "https://github.com/php-fig/event-dispatcher.git",
+                "reference": "dbefd12671e8a14ec7f180cab83036ed26714bb0"
+            },
+            "dist": {
+                "type": "zip",
+                "url": "https://api.github.com/repos/php-fig/event-dispatcher/zipball/dbefd12671e8a14ec7f180cab83036ed26714bb0",
+                "reference": "dbefd12671e8a14ec7f180cab83036ed26714bb0",
+                "shasum": ""
+            },
+            "require": {
+                "php": ">=7.2.0"
+            },
+            "type": "library",
+            "extra": {
+                "branch-alias": {
+                    "dev-master": "1.0.x-dev"
+                }
+            },
+            "autoload": {
+                "psr-4": {
+                    "Psr\\EventDispatcher\\": "src/"
+                }
+            },
+            "notification-url": "https://packagist.org/downloads/",
+            "license": [
+                "MIT"
+            ],
+            "authors": [
+                {
+                    "name": "PHP-FIG",
+                    "homepage": "http://www.php-fig.org/"
+                }
+            ],
+            "description": "Standard interfaces for event handling.",
+            "keywords": [
+                "events",
+                "psr",
+                "psr-14"
+            ],
+            "support": {
+                "issues": "https://github.com/php-fig/event-dispatcher/issues",
+                "source": "https://github.com/php-fig/event-dispatcher/tree/1.0.0"
+            },
+            "time": "2019-01-08T18:20:26+00:00"
+        },
+        {
             "name": "psr/http-client",
             "version": "1.0.3",
             "source": {
@@ -488,17 +538,68 @@
             "time": "2023-04-04T09:54:51+00:00"
         },
         {
-            "name": "wordpress/php-ai-client",
-            "version": "0.3.1",
+            "name": "psr/simple-cache",
+            "version": "1.0.1",
             "source": {
                 "type": "git",
-                "url": "https://github.com/WordPress/php-ai-client.git",
-                "reference": "48cc7de403e00d3035ce2fcb88128dea5e283444"
+                "url": "https://github.com/php-fig/simple-cache.git",
+                "reference": "408d5eafb83c57f6365a3ca330ff23aa4a5fa39b"
             },
             "dist": {
                 "type": "zip",
-                "url": "https://api.github.com/repos/WordPress/php-ai-client/zipball/48cc7de403e00d3035ce2fcb88128dea5e283444",
-                "reference": "48cc7de403e00d3035ce2fcb88128dea5e283444",
+                "url": "https://api.github.com/repos/php-fig/simple-cache/zipball/408d5eafb83c57f6365a3ca330ff23aa4a5fa39b",
+                "reference": "408d5eafb83c57f6365a3ca330ff23aa4a5fa39b",
+                "shasum": ""
+            },
+            "require": {
+                "php": ">=5.3.0"
+            },
+            "type": "library",
+            "extra": {
+                "branch-alias": {
+                    "dev-master": "1.0.x-dev"
+                }
+            },
+            "autoload": {
+                "psr-4": {
+                    "Psr\\SimpleCache\\": "src/"
+                }
+            },
+            "notification-url": "https://packagist.org/downloads/",
+            "license": [
+                "MIT"
+            ],
+            "authors": [
+                {
+                    "name": "PHP-FIG",
+                    "homepage": "http://www.php-fig.org/"
+                }
+            ],
+            "description": "Common interfaces for simple caching",
+            "keywords": [
+                "cache",
+                "caching",
+                "psr",
+                "psr-16",
+                "simple-cache"
+            ],
+            "support": {
+                "source": "https://github.com/php-fig/simple-cache/tree/master"
+            },
+            "time": "2017-10-23T01:57:42+00:00"
+        },
+        {
+            "name": "wordpress/php-ai-client",
+            "version": "0.4.0",
+            "source": {
+                "type": "git",
+                "url": "https://github.com/WordPress/php-ai-client.git",
+                "reference": "79d8ad87c7c4711bef35e93e54f9849acc592d0e"
+            },
+            "dist": {
+                "type": "zip",
+                "url": "https://api.github.com/repos/WordPress/php-ai-client/zipball/79d8ad87c7c4711bef35e93e54f9849acc592d0e",
+                "reference": "79d8ad87c7c4711bef35e93e54f9849acc592d0e",
                 "shasum": ""
             },
             "require": {
@@ -507,9 +608,11 @@
                 "php-http/discovery": "^1.0",
                 "php-http/httplug": "^2.0",
                 "php-http/message-factory": "^1.0",
+                "psr/event-dispatcher": "^1.0",
                 "psr/http-client": "^1.0",
                 "psr/http-factory": "^1.0",
-                "psr/http-message": "^1.0 || ^2.0"
+                "psr/http-message": "^1.0 || ^2.0",
+                "psr/simple-cache": "^1.0 || ^2.0 || ^3.0"
             },
             "require-dev": {
                 "dealerdirect/phpcodesniffer-composer-installer": "^1.0",
@@ -552,7 +655,7 @@
                 "issues": "https://github.com/WordPress/php-ai-client/issues",
                 "source": "https://github.com/WordPress/php-ai-client"
             },
-            "time": "2025-12-08T03:41:36+00:00"
+            "time": "2026-01-20T05:39:31+00:00"
         }
     ],
     "packages-dev": [

--- a/composer.lock
+++ b/composer.lock
@@ -590,16 +590,16 @@
         },
         {
             "name": "wordpress/php-ai-client",
-            "version": "0.4.0",
+            "version": "0.4.1",
             "source": {
                 "type": "git",
                 "url": "https://github.com/WordPress/php-ai-client.git",
-                "reference": "79d8ad87c7c4711bef35e93e54f9849acc592d0e"
+                "reference": "daef4f632320cf5e715cf595101e93ebd05803a6"
             },
             "dist": {
                 "type": "zip",
-                "url": "https://api.github.com/repos/WordPress/php-ai-client/zipball/79d8ad87c7c4711bef35e93e54f9849acc592d0e",
-                "reference": "79d8ad87c7c4711bef35e93e54f9849acc592d0e",
+                "url": "https://api.github.com/repos/WordPress/php-ai-client/zipball/daef4f632320cf5e715cf595101e93ebd05803a6",
+                "reference": "daef4f632320cf5e715cf595101e93ebd05803a6",
                 "shasum": ""
             },
             "require": {
@@ -623,7 +623,8 @@
                 "phpstan/phpstan": "~2.1",
                 "phpunit/phpunit": "^9.5 || ^10.0",
                 "slevomat/coding-standard": "^8.20",
-                "squizlabs/php_codesniffer": "^3.7"
+                "squizlabs/php_codesniffer": "^3.7",
+                "symfony/dotenv": "^5.4"
             },
             "type": "library",
             "autoload": {
@@ -655,7 +656,7 @@
                 "issues": "https://github.com/WordPress/php-ai-client/issues",
                 "source": "https://github.com/WordPress/php-ai-client"
             },
-            "time": "2026-01-20T05:39:31+00:00"
+            "time": "2026-01-27T16:33:23+00:00"
         }
     ],
     "packages-dev": [

--- a/composer.lock
+++ b/composer.lock
@@ -590,16 +590,16 @@
         },
         {
             "name": "wordpress/php-ai-client",
-            "version": "0.4.2",
+            "version": "0.4.3",
             "source": {
                 "type": "git",
                 "url": "https://github.com/WordPress/php-ai-client.git",
-                "reference": "be2521e08a590ab4098d73bbc3b3bfc45cdab5d2"
+                "reference": "b47c878b161af543f947fdb62999ecc8604998d3"
             },
             "dist": {
                 "type": "zip",
-                "url": "https://api.github.com/repos/WordPress/php-ai-client/zipball/be2521e08a590ab4098d73bbc3b3bfc45cdab5d2",
-                "reference": "be2521e08a590ab4098d73bbc3b3bfc45cdab5d2",
+                "url": "https://api.github.com/repos/WordPress/php-ai-client/zipball/b47c878b161af543f947fdb62999ecc8604998d3",
+                "reference": "b47c878b161af543f947fdb62999ecc8604998d3",
                 "shasum": ""
             },
             "require": {
@@ -656,7 +656,7 @@
                 "issues": "https://github.com/WordPress/php-ai-client/issues",
                 "source": "https://github.com/WordPress/php-ai-client"
             },
-            "time": "2026-01-31T21:20:57+00:00"
+            "time": "2026-02-04T01:11:54+00:00"
         }
     ],
     "packages-dev": [

--- a/composer.lock
+++ b/composer.lock
@@ -590,16 +590,16 @@
         },
         {
             "name": "wordpress/php-ai-client",
-            "version": "0.4.1",
+            "version": "0.4.2",
             "source": {
                 "type": "git",
                 "url": "https://github.com/WordPress/php-ai-client.git",
-                "reference": "daef4f632320cf5e715cf595101e93ebd05803a6"
+                "reference": "be2521e08a590ab4098d73bbc3b3bfc45cdab5d2"
             },
             "dist": {
                 "type": "zip",
-                "url": "https://api.github.com/repos/WordPress/php-ai-client/zipball/daef4f632320cf5e715cf595101e93ebd05803a6",
-                "reference": "daef4f632320cf5e715cf595101e93ebd05803a6",
+                "url": "https://api.github.com/repos/WordPress/php-ai-client/zipball/be2521e08a590ab4098d73bbc3b3bfc45cdab5d2",
+                "reference": "be2521e08a590ab4098d73bbc3b3bfc45cdab5d2",
                 "shasum": ""
             },
             "require": {
@@ -656,7 +656,7 @@
                 "issues": "https://github.com/WordPress/php-ai-client/issues",
                 "source": "https://github.com/WordPress/php-ai-client"
             },
-            "time": "2026-01-27T16:33:23+00:00"
+            "time": "2026-01-31T21:20:57+00:00"
         }
     ],
     "packages-dev": [

--- a/includes/AI_Client.php
+++ b/includes/AI_Client.php
@@ -12,6 +12,7 @@ use WordPress\AI_Client\API_Credentials\API_Credentials_Manager;
 use WordPress\AI_Client\Builders\Prompt_Builder;
 use WordPress\AI_Client\Builders\Prompt_Builder_With_WP_Error;
 use WordPress\AI_Client\Capabilities\Capabilities_Manager;
+use WordPress\AI_Client\Events\WordPress_Event_Dispatcher;
 use WordPress\AI_Client\HTTP\WP_AI_Client_Discovery_Strategy;
 use WordPress\AI_Client\REST_API\AI_Providers_Models_REST_Controller;
 use WordPress\AI_Client\REST_API\AI_Prompt_REST_Controller;
@@ -54,6 +55,9 @@ class AI_Client {
 
 		// Wire up the WordPress HTTP client with the PHP AI Client SDK.
 		WP_AI_Client_Discovery_Strategy::init();
+
+		// Wire up the WordPress event dispatcher with the PHP AI Client SDK.
+		AiClient::setEventDispatcher( new WordPress_Event_Dispatcher() );
 
 		// Initialize capabilities.
 		add_filter( 'user_has_cap', array( Capabilities_Manager::class, 'grant_prompt_ai_to_administrators' ) );

--- a/includes/AI_Client.php
+++ b/includes/AI_Client.php
@@ -11,6 +11,7 @@ namespace WordPress\AI_Client;
 use WordPress\AI_Client\API_Credentials\API_Credentials_Manager;
 use WordPress\AI_Client\Builders\Prompt_Builder;
 use WordPress\AI_Client\Builders\Prompt_Builder_With_WP_Error;
+use WordPress\AI_Client\Cache\WordPress_Cache;
 use WordPress\AI_Client\Capabilities\Capabilities_Manager;
 use WordPress\AI_Client\Events\WordPress_Event_Dispatcher;
 use WordPress\AI_Client\HTTP\WP_AI_Client_Discovery_Strategy;
@@ -58,6 +59,9 @@ class AI_Client {
 
 		// Wire up the WordPress event dispatcher with the PHP AI Client SDK.
 		AiClient::setEventDispatcher( new WordPress_Event_Dispatcher() );
+
+		// Wire up the WordPress cache with the PHP AI Client SDK.
+		AiClient::setCache( new WordPress_Cache() );
 
 		// Initialize capabilities.
 		add_filter( 'user_has_cap', array( Capabilities_Manager::class, 'grant_prompt_ai_to_administrators' ) );

--- a/includes/Cache/WordPress_Cache.php
+++ b/includes/Cache/WordPress_Cache.php
@@ -1,0 +1,212 @@
+<?php
+/**
+ * Class WordPress\AI_Client\Cache\WordPress_Cache
+ *
+ * @since n.e.x.t
+ * @package WordPress\AI_Client
+ */
+
+namespace WordPress\AI_Client\Cache;
+
+use DateInterval;
+use DateTime;
+use Psr\SimpleCache\CacheInterface;
+
+/**
+ * WordPress-specific PSR-16 cache adapter.
+ *
+ * Bridges PSR-16 cache operations to WordPress object cache functions,
+ * enabling the AI client to leverage WordPress caching infrastructure.
+ *
+ * @since n.e.x.t
+ */
+class WordPress_Cache implements CacheInterface {
+
+	/**
+	 * Cache group used for all cache operations.
+	 *
+	 * @since n.e.x.t
+	 * @var string
+	 */
+	private const CACHE_GROUP = 'wp_ai_client';
+
+	/**
+	 * Fetches a value from the cache.
+	 *
+	 * @since n.e.x.t
+	 *
+	 * @param string $key           The unique key of this item in the cache.
+	 * @param mixed  $default_value Default value to return if the key does not exist.
+	 * @return mixed The value of the item from the cache, or $default_value in case of cache miss.
+	 */
+	public function get( $key, $default_value = null ) {
+		$found = false;
+		$value = wp_cache_get( $key, self::CACHE_GROUP, false, $found );
+
+		if ( ! $found ) {
+			return $default_value;
+		}
+
+		return $value;
+	}
+
+	/**
+	 * Persists data in the cache, uniquely referenced by a key with an optional expiration TTL time.
+	 *
+	 * @since n.e.x.t
+	 *
+	 * @param string                $key   The key of the item to store.
+	 * @param mixed                 $value The value of the item to store, must be serializable.
+	 * @param null|int|DateInterval $ttl   Optional. The TTL value of this item.
+	 * @return bool True on success and false on failure.
+	 */
+	public function set( $key, $value, $ttl = null ): bool {
+		$expire = $this->ttl_to_seconds( $ttl );
+
+		return wp_cache_set( $key, $value, self::CACHE_GROUP, $expire );
+	}
+
+	/**
+	 * Delete an item from the cache by its unique key.
+	 *
+	 * @since n.e.x.t
+	 *
+	 * @param string $key The unique cache key of the item to delete.
+	 * @return bool True if the item was successfully removed. False if there was an error.
+	 */
+	public function delete( $key ): bool {
+		return wp_cache_delete( $key, self::CACHE_GROUP );
+	}
+
+	/**
+	 * Wipes clean the entire cache's keys.
+	 *
+	 * This method only clears the cache group used by this adapter. If the underlying
+	 * cache implementation does not support group flushing, this method returns false.
+	 *
+	 * @since n.e.x.t
+	 *
+	 * @return bool True on success and false on failure.
+	 */
+	public function clear(): bool {
+		if ( ! function_exists( 'wp_cache_supports' ) || ! wp_cache_supports( 'flush_group' ) ) {
+			return false;
+		}
+
+		return wp_cache_flush_group( self::CACHE_GROUP );
+	}
+
+	/**
+	 * Obtains multiple cache items by their unique keys.
+	 *
+	 * @since n.e.x.t
+	 *
+	 * @param iterable<string> $keys          A list of keys that can be obtained in a single operation.
+	 * @param mixed            $default_value Default value to return for keys that do not exist.
+	 * @return array<string, mixed> A list of key => value pairs.
+	 */
+	public function getMultiple( $keys, $default_value = null ) {
+		/**
+		 * Keys array.
+		 *
+		 * @var array<string> $keys_array
+		 */
+		$keys_array = $this->iterable_to_array( $keys );
+		$values     = wp_cache_get_multiple( $keys_array, self::CACHE_GROUP );
+		$result     = array();
+
+		foreach ( $keys_array as $key ) {
+			$result[ $key ] = isset( $values[ $key ] ) && false !== $values[ $key ] ? $values[ $key ] : $default_value;
+		}
+
+		return $result;
+	}
+
+	/**
+	 * Persists a set of key => value pairs in the cache, with an optional TTL.
+	 *
+	 * @since n.e.x.t
+	 *
+	 * @param iterable<string, mixed> $values A list of key => value pairs for a multiple-set operation.
+	 * @param null|int|DateInterval   $ttl    Optional. The TTL value of this item.
+	 * @return bool True on success and false on failure.
+	 */
+	public function setMultiple( $values, $ttl = null ): bool {
+		$values_array = $this->iterable_to_array( $values );
+		$expire       = $this->ttl_to_seconds( $ttl );
+		$results      = wp_cache_set_multiple( $values_array, self::CACHE_GROUP, $expire );
+
+		// Return true only if all operations succeeded.
+		return ! in_array( false, $results, true );
+	}
+
+	/**
+	 * Deletes multiple cache items in a single operation.
+	 *
+	 * @since n.e.x.t
+	 *
+	 * @param iterable<string> $keys A list of string-based keys to be deleted.
+	 * @return bool True if the items were successfully removed. False if there was an error.
+	 */
+	public function deleteMultiple( $keys ): bool {
+		$keys_array = $this->iterable_to_array( $keys );
+		$results    = wp_cache_delete_multiple( $keys_array, self::CACHE_GROUP );
+
+		// Return true only if all operations succeeded.
+		return ! in_array( false, $results, true );
+	}
+
+	/**
+	 * Determines whether an item is present in the cache.
+	 *
+	 * @since n.e.x.t
+	 *
+	 * @param string $key The cache item key.
+	 * @return bool True if the item exists in the cache, false otherwise.
+	 */
+	public function has( $key ): bool {
+		$found = false;
+		wp_cache_get( $key, self::CACHE_GROUP, false, $found );
+
+		return (bool) $found;
+	}
+
+	/**
+	 * Converts a PSR-16 TTL value to seconds for WordPress cache functions.
+	 *
+	 * @since n.e.x.t
+	 *
+	 * @param null|int|DateInterval $ttl The TTL value.
+	 * @return int The TTL in seconds, or 0 for no expiration.
+	 */
+	private function ttl_to_seconds( $ttl ): int {
+		if ( null === $ttl ) {
+			return 0;
+		}
+
+		if ( $ttl instanceof DateInterval ) {
+			$now = new DateTime();
+			$end = ( clone $now )->add( $ttl );
+
+			return $end->getTimestamp() - $now->getTimestamp();
+		}
+
+		return max( 0, (int) $ttl );
+	}
+
+	/**
+	 * Converts an iterable to an array.
+	 *
+	 * @since n.e.x.t
+	 *
+	 * @param iterable<mixed> $items The iterable to convert.
+	 * @return array<mixed> The array.
+	 */
+	private function iterable_to_array( $items ): array {
+		if ( is_array( $items ) ) {
+			return $items;
+		}
+
+		return iterator_to_array( $items );
+	}
+}

--- a/includes/Events/WordPress_Event_Dispatcher.php
+++ b/includes/Events/WordPress_Event_Dispatcher.php
@@ -42,6 +42,11 @@ class WordPress_Event_Dispatcher implements EventDispatcherInterface {
 		 * For example, an event class named `BeforeGenerateResultEvent` will fire the
 		 * `wp_ai_client_before_generate_result` action hook.
 		 *
+		 * In practice, the available action hook names are:
+		 *
+		 * - wp_ai_client_before_generate_result
+		 * - wp_ai_client_after_generate_result
+		 *
 		 * @since n.e.x.t
 		 *
 		 * @param object $event The event object.

--- a/includes/Events/WordPress_Event_Dispatcher.php
+++ b/includes/Events/WordPress_Event_Dispatcher.php
@@ -1,0 +1,74 @@
+<?php
+/**
+ * Class WordPress\AI_Client\Events\WordPress_Event_Dispatcher
+ *
+ * @since n.e.x.t
+ * @package WordPress\AI_Client
+ */
+
+namespace WordPress\AI_Client\Events;
+
+use Psr\EventDispatcher\EventDispatcherInterface;
+
+/**
+ * WordPress-specific PSR-14 event dispatcher.
+ *
+ * Bridges PSR-14 events to WordPress action hooks, enabling plugins to hook into AI client events.
+ *
+ * @since n.e.x.t
+ */
+class WordPress_Event_Dispatcher implements EventDispatcherInterface {
+
+	/**
+	 * Dispatches an event to WordPress action hooks.
+	 *
+	 * Converts the event class name to a WordPress action hook name and fires it.
+	 * For example, BeforeGenerateResultEvent becomes wp_ai_client_before_generate_result.
+	 *
+	 * @since n.e.x.t
+	 *
+	 * @param object $event The event object to dispatch.
+	 * @return object The same event object, potentially modified by listeners.
+	 */
+	public function dispatch( object $event ): object {
+		$event_name = $this->get_hook_name_portion_for_event( $event );
+
+		/**
+		 * Fires when an AI client event is dispatched.
+		 *
+		 * The dynamic portion of the hook name, `$event_name`, refers to the
+		 * snake_case version of the event class name, without the `_event` suffix.
+		 *
+		 * @since n.e.x.t
+		 *
+		 * @param object $event The event object.
+		 */
+		do_action( "wp_ai_client_{$event_name}", $event );
+
+		return $event;
+	}
+
+	/**
+	 * Converts an event object class name to a WordPress action hook name portion.
+	 *
+	 * @since n.e.x.t
+	 *
+	 * @param object $event The event object.
+	 * @return string The WordPress action hook name.
+	 */
+	private function get_hook_name_portion_for_event( object $event ): string {
+		$class_name = get_class( $event );
+		$pos        = strrpos( $class_name, '\\' );
+		$short_name = false !== $pos ? substr( $class_name, $pos + 1 ) : $class_name;
+
+		// Convert PascalCase to snake_case.
+		$snake_case = strtolower( (string) preg_replace( '/([a-z])([A-Z])/', '$1_$2', $short_name ) );
+
+		// Strip '_event' suffix if present.
+		if ( str_ends_with( $snake_case, '_event' ) ) {
+			$snake_case = (string) substr( $snake_case, 0, -6 );
+		}
+
+		return $snake_case;
+	}
+}

--- a/includes/Events/WordPress_Event_Dispatcher.php
+++ b/includes/Events/WordPress_Event_Dispatcher.php
@@ -39,6 +39,9 @@ class WordPress_Event_Dispatcher implements EventDispatcherInterface {
 		 * The dynamic portion of the hook name, `$event_name`, refers to the
 		 * snake_case version of the event class name, without the `_event` suffix.
 		 *
+		 * For example, an event class named `BeforeGenerateResultEvent` will fire the
+		 * `wp_ai_client_before_generate_result` action hook.
+		 *
 		 * @since n.e.x.t
 		 *
 		 * @param object $event The event object.

--- a/tests/phpunit/includes/Mock_Event.php
+++ b/tests/phpunit/includes/Mock_Event.php
@@ -1,0 +1,16 @@
+<?php
+/**
+ * Mock Event for testing.
+ *
+ * @package WordPress\AI_Client
+ */
+
+namespace WordPress\AI_Client\PHPUnit\Includes;
+
+/**
+ * Mock event class for testing the WordPress_Event_Dispatcher.
+ *
+ * The class name ends with 'Event' to test the suffix stripping behavior.
+ */
+class Mock_Event {
+}

--- a/tests/phpunit/tests/Cache/WordPress_Cache_Tests.php
+++ b/tests/phpunit/tests/Cache/WordPress_Cache_Tests.php
@@ -1,0 +1,253 @@
+<?php
+/**
+ * Tests for WordPress\AI_Client\Cache\WordPress_Cache
+ *
+ * @package WordPress\AI_Client
+ */
+
+namespace WordPress\AI_Client\PHPUnit\Tests\Cache;
+
+use DateInterval;
+use WordPress\AI_Client\Cache\WordPress_Cache;
+use WordPress\AI_Client\PHPUnit\Includes\Test_Case;
+
+class WordPress_Cache_Tests extends Test_Case {
+
+	/**
+	 * The cache instance.
+	 *
+	 * @var WordPress_Cache
+	 */
+	private $cache;
+
+	public function set_up(): void {
+		parent::set_up();
+		$this->cache = new WordPress_Cache();
+	}
+
+	/**
+	 * Tests that get returns the cached value.
+	 */
+	public function test_get_returns_cached_value(): void {
+		wp_cache_set( 'test_key', 'test_value', 'wp_ai_client' );
+
+		$this->assertSame( 'test_value', $this->cache->get( 'test_key' ) );
+	}
+
+	/**
+	 * Tests that get returns default value for missing key.
+	 */
+	public function test_get_returns_default_for_missing_key(): void {
+		$this->assertNull( $this->cache->get( 'nonexistent_key' ) );
+		$this->assertSame( 'default', $this->cache->get( 'nonexistent_key', 'default' ) );
+	}
+
+	/**
+	 * Tests that set stores a value in the cache.
+	 */
+	public function test_set_stores_value(): void {
+		$result = $this->cache->set( 'test_key', 'test_value' );
+
+		$this->assertTrue( $result );
+		$this->assertSame( 'test_value', wp_cache_get( 'test_key', 'wp_ai_client' ) );
+	}
+
+	/**
+	 * Tests that set handles different value types.
+	 */
+	public function test_set_handles_different_types(): void {
+		$this->cache->set( 'string_key', 'string_value' );
+		$this->cache->set( 'int_key', 42 );
+		$this->cache->set( 'array_key', array( 'foo' => 'bar' ) );
+		$this->cache->set( 'bool_key', true );
+
+		$this->assertSame( 'string_value', $this->cache->get( 'string_key' ) );
+		$this->assertSame( 42, $this->cache->get( 'int_key' ) );
+		$this->assertSame( array( 'foo' => 'bar' ), $this->cache->get( 'array_key' ) );
+		$this->assertTrue( $this->cache->get( 'bool_key' ) );
+	}
+
+	/**
+	 * Tests that set accepts DateInterval TTL.
+	 */
+	public function test_set_accepts_date_interval_ttl(): void {
+		$ttl    = new DateInterval( 'PT1H' ); // 1 hour.
+		$result = $this->cache->set( 'test_key', 'test_value', $ttl );
+
+		$this->assertTrue( $result );
+		$this->assertSame( 'test_value', $this->cache->get( 'test_key' ) );
+	}
+
+	/**
+	 * Tests that set accepts integer TTL.
+	 */
+	public function test_set_accepts_integer_ttl(): void {
+		$result = $this->cache->set( 'test_key', 'test_value', 3600 );
+
+		$this->assertTrue( $result );
+		$this->assertSame( 'test_value', $this->cache->get( 'test_key' ) );
+	}
+
+	/**
+	 * Tests that delete removes an item from the cache.
+	 */
+	public function test_delete_removes_item(): void {
+		$this->cache->set( 'test_key', 'test_value' );
+
+		$result = $this->cache->delete( 'test_key' );
+
+		$this->assertTrue( $result );
+		$this->assertNull( $this->cache->get( 'test_key' ) );
+	}
+
+	/**
+	 * Tests that delete returns false for nonexistent key.
+	 */
+	public function test_delete_nonexistent_key(): void {
+		$result = $this->cache->delete( 'nonexistent_key' );
+
+		// WordPress wp_cache_delete returns false for nonexistent keys.
+		$this->assertFalse( $result );
+	}
+
+	/**
+	 * Tests that has returns true for existing key.
+	 */
+	public function test_has_returns_true_for_existing_key(): void {
+		$this->cache->set( 'test_key', 'test_value' );
+
+		$this->assertTrue( $this->cache->has( 'test_key' ) );
+	}
+
+	/**
+	 * Tests that has returns false for missing key.
+	 */
+	public function test_has_returns_false_for_missing_key(): void {
+		$this->assertFalse( $this->cache->has( 'nonexistent_key' ) );
+	}
+
+	/**
+	 * Tests that has returns true for falsy cached values.
+	 */
+	public function test_has_returns_true_for_falsy_values(): void {
+		$this->cache->set( 'null_key', null );
+		$this->cache->set( 'false_key', false );
+		$this->cache->set( 'zero_key', 0 );
+		$this->cache->set( 'empty_string_key', '' );
+
+		$this->assertTrue( $this->cache->has( 'null_key' ) );
+		$this->assertTrue( $this->cache->has( 'false_key' ) );
+		$this->assertTrue( $this->cache->has( 'zero_key' ) );
+		$this->assertTrue( $this->cache->has( 'empty_string_key' ) );
+	}
+
+	/**
+	 * Tests that getMultiple returns values for multiple keys.
+	 */
+	public function test_get_multiple_returns_values(): void {
+		$this->cache->set( 'key1', 'value1' );
+		$this->cache->set( 'key2', 'value2' );
+		$this->cache->set( 'key3', 'value3' );
+
+		$result = $this->cache->getMultiple( array( 'key1', 'key2', 'key3' ) );
+
+		$this->assertSame(
+			array(
+				'key1' => 'value1',
+				'key2' => 'value2',
+				'key3' => 'value3',
+			),
+			$result
+		);
+	}
+
+	/**
+	 * Tests that getMultiple returns default for missing keys.
+	 */
+	public function test_get_multiple_returns_default_for_missing(): void {
+		$this->cache->set( 'key1', 'value1' );
+
+		$result = $this->cache->getMultiple( array( 'key1', 'missing_key' ), 'default' );
+
+		$this->assertSame(
+			array(
+				'key1'        => 'value1',
+				'missing_key' => 'default',
+			),
+			$result
+		);
+	}
+
+	/**
+	 * Tests that setMultiple stores multiple values.
+	 */
+	public function test_set_multiple_stores_values(): void {
+		$result = $this->cache->setMultiple(
+			array(
+				'key1' => 'value1',
+				'key2' => 'value2',
+				'key3' => 'value3',
+			)
+		);
+
+		$this->assertTrue( $result );
+		$this->assertSame( 'value1', $this->cache->get( 'key1' ) );
+		$this->assertSame( 'value2', $this->cache->get( 'key2' ) );
+		$this->assertSame( 'value3', $this->cache->get( 'key3' ) );
+	}
+
+	/**
+	 * Tests that deleteMultiple removes multiple items.
+	 */
+	public function test_delete_multiple_removes_items(): void {
+		$this->cache->setMultiple(
+			array(
+				'key1' => 'value1',
+				'key2' => 'value2',
+				'key3' => 'value3',
+			)
+		);
+
+		$result = $this->cache->deleteMultiple( array( 'key1', 'key2' ) );
+
+		$this->assertTrue( $result );
+		$this->assertFalse( $this->cache->has( 'key1' ) );
+		$this->assertFalse( $this->cache->has( 'key2' ) );
+		$this->assertTrue( $this->cache->has( 'key3' ) );
+	}
+
+	/**
+	 * Tests that clear clears the cache group when group flushing is supported.
+	 */
+	public function test_clear_clears_group_with_flush_group_support(): void {
+		if ( ! function_exists( 'wp_cache_supports' ) || ! wp_cache_supports( 'flush_group' ) ) {
+			$this->markTestSkipped( 'Test requires cache with group flush support.' );
+		}
+
+		$this->cache->set( 'key1', 'value1' );
+		$this->cache->set( 'key2', 'value2' );
+
+		$result = $this->cache->clear();
+
+		$this->assertTrue( $result );
+		$this->assertFalse( $this->cache->has( 'key1' ) );
+		$this->assertFalse( $this->cache->has( 'key2' ) );
+	}
+
+	/**
+	 * Tests that clear returns false when group flushing is not supported.
+	 */
+	public function test_clear_returns_false_without_flush_group_support(): void {
+		// The default WordPress object cache does not support group flushing.
+		// wp_cache_supports('flush_group') returns false by default.
+		if ( function_exists( 'wp_cache_supports' ) && wp_cache_supports( 'flush_group' ) ) {
+			$this->markTestSkipped( 'Test requires cache without group flush support.' );
+		}
+
+		$this->cache->set( 'test_key', 'test_value' );
+
+		$result = $this->cache->clear();
+
+		$this->assertFalse( $result );
+	}
+}

--- a/tests/phpunit/tests/Events/WordPress_Event_Dispatcher_Tests.php
+++ b/tests/phpunit/tests/Events/WordPress_Event_Dispatcher_Tests.php
@@ -1,0 +1,56 @@
+<?php
+/**
+ * Tests for WordPress\AI_Client\Events\WordPress_Event_Dispatcher
+ *
+ * @package WordPress\AI_Client
+ */
+
+namespace WordPress\AI_Client\PHPUnit\Tests\Events;
+
+use stdClass;
+use WordPress\AI_Client\Events\WordPress_Event_Dispatcher;
+use WordPress\AI_Client\PHPUnit\Includes\Mock_Event;
+use WordPress\AI_Client\PHPUnit\Includes\Test_Case;
+
+class WordPress_Event_Dispatcher_Tests extends Test_Case {
+
+	/**
+	 * Tests that dispatch fires the correct WordPress action hook.
+	 */
+	public function test_dispatch_fires_action_hook(): void {
+		$dispatcher = new WordPress_Event_Dispatcher();
+		$event      = new Mock_Event();
+
+		$hook_fired   = false;
+		$passed_event = null;
+
+		add_action(
+			'wp_ai_client_mock',
+			static function ( $event ) use ( &$hook_fired, &$passed_event ) {
+				$hook_fired   = true;
+				$passed_event = $event;
+			}
+		);
+
+		$returned_event = $dispatcher->dispatch( $event );
+
+		$this->assertTrue( $hook_fired, 'The action hook should have been fired.' );
+		$this->assertSame( $event, $passed_event, 'The event object should be passed to the action hook.' );
+		$this->assertSame( $event, $returned_event, 'The dispatch method should return the same event object.' );
+	}
+
+	/**
+	 * Tests that dispatch returns the event object unmodified when no listeners are attached.
+	 */
+	public function test_dispatch_returns_event_without_listeners(): void {
+		$dispatcher = new WordPress_Event_Dispatcher();
+		$event      = new stdClass();
+
+		$event->test_value = 'original';
+
+		$returned_event = $dispatcher->dispatch( $event );
+
+		$this->assertSame( $event, $returned_event, 'The dispatch method should return the same event object.' );
+		$this->assertSame( 'original', $returned_event->test_value, 'The event properties should be unchanged.' );
+	}
+}


### PR DESCRIPTION
* Updates `wordpress/php-ai-client` to 0.4.0
* Implements PSR-14 `WordPress_Event_Dispatcher`
* Implements PSR-16 `WordPress_Cache` (using a `wp_ai_client` cache group to keep things scoped)