### PR TITLE
Fix Prompt_Builder::using_abilities return type.

### DIFF
--- a/includes/Builders/Prompt_Builder.php
+++ b/includes/Builders/Prompt_Builder.php
@@ -143,9 +143,9 @@ class Prompt_Builder {
 	 * @since 0.2.1 Renamed from `using_ability` to `using_abilities`.
 	 *
 	 * @param WP_Ability|string ...$abilities The abilities to register, either as WP_Ability objects or ability name strings.
-	 * @return self The current instance for method chaining.
+	 * @return static The current instance for method chaining.
 	 */
-	public function using_abilities( ...$abilities ): self {
+	public function using_abilities( ...$abilities ): static {
 		$declarations = array();
 
 		foreach ( $abilities as $ability ) {


### PR DESCRIPTION
It should return a static type for correct typing in child classes like Prompt_Builder_With_WP_Error.