### PR TITLE
Adds support for restricting prompt execution

### DIFF
--- a/includes/Builders/Exception/Prompt_Prevented_Exception.php
+++ b/includes/Builders/Exception/Prompt_Prevented_Exception.php
@@ -1,0 +1,20 @@
+<?php
+/**
+ * Class WordPress\AI_Client\Builders\Exception\Prompt_Prevented_Exception
+ *
+ * @since n.e.x.t
+ * @package WordPress\AI_Client
+ */
+
+namespace WordPress\AI_Client\Builders\Exception;
+
+use RuntimeException;
+
+/**
+ * Exception thrown when a prompt is prevented from executing by the wp_ai_client_prevent_prompt filter.
+ *
+ * @since n.e.x.t
+ */
+class Prompt_Prevented_Exception extends RuntimeException {
+
+}

--- a/includes/Builders/Prompt_Builder.php
+++ b/includes/Builders/Prompt_Builder.php
@@ -9,7 +9,7 @@
 namespace WordPress\AI_Client\Builders;
 
 use BadMethodCallException;
-use RuntimeException;
+use WordPress\AI_Client\Builders\Exception\Prompt_Prevented_Exception;
 use WordPress\AiClient\Builders\PromptBuilder;
 use WordPress\AiClient\Files\DTO\File;
 use WordPress\AiClient\Files\Enums\FileTypeEnum;
@@ -186,7 +186,7 @@ class Prompt_Builder {
 	 * @param array<int, mixed> $arguments The method arguments.
 	 * @return mixed The result of the parent method call.
 	 *
-	 * @throws RuntimeException If a generation method is called and the prompt was prevented by filter.
+	 * @throws Prompt_Prevented_Exception If a generation method is called and the prompt was prevented by filter.
 	 */
 	public function __call( string $name, array $arguments ) {
 		// Check if the prompt should be prevented for is_supported* and generate_*/convert_text_to_speech* methods.
@@ -208,7 +208,7 @@ class Prompt_Builder {
 				}
 
 				// For generate_* and convert_text_to_speech* methods, throw an exception.
-				throw new RuntimeException( 'Prompt execution was prevented by a filter.' );
+				throw new Prompt_Prevented_Exception( 'Prompt execution was prevented by a filter.' );
 			}
 		}
 

--- a/includes/Builders/Prompt_Builder.php
+++ b/includes/Builders/Prompt_Builder.php
@@ -9,6 +9,7 @@
 namespace WordPress\AI_Client\Builders;
 
 use BadMethodCallException;
+use RuntimeException;
 use WordPress\AiClient\Builders\PromptBuilder;
 use WordPress\AiClient\Files\DTO\File;
 use WordPress\AiClient\Files\Enums\FileTypeEnum;
@@ -184,8 +185,33 @@ class Prompt_Builder {
 	 * @param string            $name      The method name in snake_case.
 	 * @param array<int, mixed> $arguments The method arguments.
 	 * @return mixed The result of the parent method call.
+	 *
+	 * @throws RuntimeException If a generation method is called and the prompt was prevented by filter.
 	 */
 	public function __call( string $name, array $arguments ) {
+		// Check if the prompt should be prevented for is_supported* and generate_*/convert_text_to_speech* methods.
+		if ( $this->is_support_check_method( $name ) || $this->is_generating_method( $name ) ) {
+			/**
+			 * Filters whether to prevent the prompt from being executed.
+			 *
+			 * @since n.e.x.t
+			 *
+			 * @param bool           $prevent Whether to prevent the prompt. Default false.
+			 * @param Prompt_Builder $builder The prompt builder instance.
+			 */
+			$prevent = (bool) apply_filters( 'wp_ai_client_prevent_prompt', false, $this );
+
+			if ( $prevent ) {
+				// For is_supported* methods, return false.
+				if ( $this->is_support_check_method( $name ) ) {
+					return false;
+				}
+
+				// For generate_* and convert_text_to_speech* methods, throw an exception.
+				throw new RuntimeException( 'Prompt execution was prevented by a filter.' );
+			}
+		}
+
 		$callable = $this->get_builder_callable( $name );
 		$result   = $callable( ...$arguments );
 
@@ -195,6 +221,31 @@ class Prompt_Builder {
 		}
 
 		return $result;
+	}
+
+	/**
+	 * Checks if a method name is a support check method (is_supported*).
+	 *
+	 * @since n.e.x.t
+	 *
+	 * @param string $name The method name.
+	 * @return bool True if the method is a support check method, false otherwise.
+	 */
+	protected function is_support_check_method( string $name ): bool {
+		return str_starts_with( $name, 'is_supported' );
+	}
+
+	/**
+	 * Checks if a method name is a generating method (generate_*, convert_text_to_speech*).
+	 *
+	 * @since n.e.x.t
+	 *
+	 * @param string $name The method name.
+	 * @return bool True if the method is a generating method, false otherwise.
+	 */
+	protected function is_generating_method( string $name ): bool {
+		return str_starts_with( $name, 'generate_' )
+			|| str_starts_with( $name, 'convert_text_to_speech' );
 	}
 
 	/**

--- a/includes/Builders/Prompt_Builder.php
+++ b/includes/Builders/Prompt_Builder.php
@@ -191,17 +191,15 @@ class Prompt_Builder {
 	public function __call( string $name, array $arguments ) {
 		// Check if the prompt should be prevented for is_supported* and generate_*/convert_text_to_speech* methods.
 		if ( $this->is_support_check_method( $name ) || $this->is_generating_method( $name ) ) {
-			$builder = $this;
-
 			/**
 			 * Filters whether to prevent the prompt from being executed.
 			 *
 			 * @since n.e.x.t
 			 *
 			 * @param bool           $prevent Whether to prevent the prompt. Default false.
-			 * @param Prompt_Builder $builder The prompt builder instance.
+			 * @param Prompt_Builder $builder A clone of the prompt builder instance (read-only).
 			 */
-			$prevent = (bool) apply_filters( 'wp_ai_client_prevent_prompt', false, $builder );
+			$prevent = (bool) apply_filters( 'wp_ai_client_prevent_prompt', false, clone $this );
 
 			if ( $prevent ) {
 				// For is_supported* methods, return false.

--- a/includes/Builders/Prompt_Builder.php
+++ b/includes/Builders/Prompt_Builder.php
@@ -191,6 +191,8 @@ class Prompt_Builder {
 	public function __call( string $name, array $arguments ) {
 		// Check if the prompt should be prevented for is_supported* and generate_*/convert_text_to_speech* methods.
 		if ( $this->is_support_check_method( $name ) || $this->is_generating_method( $name ) ) {
+			$builder = $this;
+
 			/**
 			 * Filters whether to prevent the prompt from being executed.
 			 *
@@ -199,7 +201,7 @@ class Prompt_Builder {
 			 * @param bool           $prevent Whether to prevent the prompt. Default false.
 			 * @param Prompt_Builder $builder The prompt builder instance.
 			 */
-			$prevent = (bool) apply_filters( 'wp_ai_client_prevent_prompt', false, $this );
+			$prevent = (bool) apply_filters( 'wp_ai_client_prevent_prompt', false, $builder );
 
 			if ( $prevent ) {
 				// For is_supported* methods, return false.

--- a/includes/Builders/Prompt_Builder_With_WP_Error.php
+++ b/includes/Builders/Prompt_Builder_With_WP_Error.php
@@ -161,7 +161,7 @@ class Prompt_Builder_With_WP_Error extends Prompt_Builder {
 				return $this->error;
 			}
 			return $this;
-		} catch ( Exception $e ) { // @phpstan-ignore catch.neverThrown (BadMethodCallException and others can be thrown by parent)
+		} catch ( Exception $e ) { // @phpstan-ignore catch.neverThrown (Other exceptions can be thrown by underlying builder)
 			$this->error = new WP_Error(
 				'prompt_builder_error',
 				$e->getMessage(),

--- a/includes/Builders/Prompt_Builder_With_WP_Error.php
+++ b/includes/Builders/Prompt_Builder_With_WP_Error.php
@@ -18,7 +18,6 @@ use WordPress\AiClient\Messages\Enums\ModalityEnum;
 use WordPress\AiClient\Providers\Models\Contracts\ModelInterface;
 use WordPress\AiClient\Providers\Models\DTO\ModelConfig;
 use WordPress\AiClient\Providers\Models\Enums\CapabilityEnum;
-use WordPress\AiClient\Providers\ProviderRegistry;
 use WordPress\AiClient\Results\DTO\GenerativeAiResult;
 use WordPress\AiClient\Tools\DTO\FunctionDeclaration;
 use WordPress\AiClient\Tools\DTO\FunctionResponse;
@@ -141,6 +140,25 @@ class Prompt_Builder_With_WP_Error extends Prompt_Builder {
 				return $this->error;
 			}
 			return $this;
+		}
+
+		// Check if the prompt should be prevented for is_supported* and generate_*/convert_text_to_speech* methods.
+		if ( $this->is_support_check_method( $name ) || $this->is_generating_method( $name ) ) {
+			/** This filter is documented in includes/Builders/Prompt_Builder.php */
+			$prevent = (bool) apply_filters( 'wp_ai_client_prevent_prompt', false, $this );
+
+			if ( $prevent ) {
+				// For is_supported* methods, return false.
+				if ( $this->is_support_check_method( $name ) ) {
+					return false;
+				}
+
+				// For generate_* and convert_text_to_speech* methods, return WP_Error.
+				return new WP_Error(
+					'prompt_prevented',
+					'Prompt execution was prevented by a filter.'
+				);
+			}
 		}
 
 		try {

--- a/includes/Builders/Prompt_Builder_With_WP_Error.php
+++ b/includes/Builders/Prompt_Builder_With_WP_Error.php
@@ -9,7 +9,7 @@
 namespace WordPress\AI_Client\Builders;
 
 use Exception;
-use WordPress\AiClient\Builders\PromptBuilder;
+use WordPress\AI_Client\Builders\Exception\Prompt_Prevented_Exception;
 use WordPress\AiClient\Files\DTO\File;
 use WordPress\AiClient\Files\Enums\FileTypeEnum;
 use WordPress\AiClient\Messages\DTO\Message;
@@ -128,9 +128,6 @@ class Prompt_Builder_With_WP_Error extends Prompt_Builder {
 	 * @return mixed The result of the parent method call.
 	 */
 	public function __call( string $name, array $arguments ) {
-		// This may throw, which is fine because calls to methods that don't exist always throw.
-		$callable = $this->get_builder_callable( $name );
-
 		/*
 		 * If an error occurred in a previous method call, either return the error for terminate methods,
 		 * or return the same instance for other methods to maintain the fluent interface.
@@ -142,35 +139,29 @@ class Prompt_Builder_With_WP_Error extends Prompt_Builder {
 			return $this;
 		}
 
-		// Check if the prompt should be prevented for is_supported* and generate_*/convert_text_to_speech* methods.
-		if ( $this->is_support_check_method( $name ) || $this->is_generating_method( $name ) ) {
-			/** This filter is documented in includes/Builders/Prompt_Builder.php */
-			$prevent = (bool) apply_filters( 'wp_ai_client_prevent_prompt', false, $this );
-
-			if ( $prevent ) {
-				// For is_supported* methods, return false.
-				if ( $this->is_support_check_method( $name ) ) {
-					return false;
-				}
-
-				// For generate_* and convert_text_to_speech* methods, return WP_Error.
-				return new WP_Error(
-					'prompt_prevented',
-					'Prompt execution was prevented by a filter.'
-				);
-			}
-		}
-
 		try {
-			$result = $callable( ...$arguments );
+			$result = parent::__call( $name, $arguments );
 
-			// If the result is a PromptBuilder, return the current instance to allow method chaining.
-			if ( $result instanceof PromptBuilder ) {
+			// If the result is $this from parent (for chaining), return $this child instance instead.
+			if ( $result instanceof self ) {
 				return $this;
 			}
 
 			return $result;
-		} catch ( Exception $e ) {
+		} catch ( Prompt_Prevented_Exception $e ) {
+			$this->error = new WP_Error(
+				'prompt_prevented',
+				$e->getMessage(),
+				array(
+					'exception_class' => get_class( $e ),
+				)
+			);
+
+			if ( self::is_terminating_method( $name ) ) {
+				return $this->error;
+			}
+			return $this;
+		} catch ( Exception $e ) { // @phpstan-ignore catch.neverThrown (BadMethodCallException and others can be thrown by parent)
 			$this->error = new WP_Error(
 				'prompt_builder_error',
 				$e->getMessage(),

--- a/tests/phpunit/tests/Builders/Prompt_Builder_Tests.php
+++ b/tests/phpunit/tests/Builders/Prompt_Builder_Tests.php
@@ -2281,11 +2281,11 @@ class Prompt_Builder_Tests extends Test_Case {
 	}
 
 	/**
-	 * Tests that prevent prompt filter receives the builder instance.
+	 * Tests that prevent prompt filter receives a clone of the builder instance.
 	 *
 	 * @return void
 	 */
-	public function test_prevent_prompt_filter_receives_builder_instance(): void {
+	public function test_prevent_prompt_filter_receives_cloned_builder_instance(): void {
 		$captured_builder = null;
 
 		add_filter(
@@ -2301,6 +2301,7 @@ class Prompt_Builder_Tests extends Test_Case {
 		$builder = new Prompt_Builder( AiClient::defaultRegistry(), 'Test prompt' );
 		$builder->is_supported();
 
-		$this->assertSame( $builder, $captured_builder );
+		$this->assertNotSame( $builder, $captured_builder, 'Filter should receive a clone, not the same instance' );
+		$this->assertInstanceOf( Prompt_Builder::class, $captured_builder );
 	}
 }

--- a/tests/phpunit/tests/Builders/Prompt_Builder_Tests.php
+++ b/tests/phpunit/tests/Builders/Prompt_Builder_Tests.php
@@ -2303,18 +2303,4 @@ class Prompt_Builder_Tests extends Test_Case {
 
 		$this->assertSame( $builder, $captured_builder );
 	}
-
-	/**
-	 * Tests that is_supported works normally when filter returns false (default).
-	 *
-	 * @return void
-	 */
-	public function test_is_supported_works_normally_when_filter_returns_false(): void {
-		add_filter( 'wp_ai_client_prevent_prompt', '__return_false' );
-
-		$builder = new Prompt_Builder( AiClient::defaultRegistry(), 'Test prompt' );
-
-		// Should delegate to underlying builder and return true for text generation support.
-		$this->assertTrue( $builder->is_supported_for_text_generation() );
-	}
 }

--- a/tests/phpunit/tests/Builders/Prompt_Builder_Tests.php
+++ b/tests/phpunit/tests/Builders/Prompt_Builder_Tests.php
@@ -2249,4 +2249,71 @@ class Prompt_Builder_Tests extends Test_Case {
 		$this->assertEquals( 'You are a helpful assistant', $config->getSystemInstruction() );
 		$this->assertEquals( 500, $config->getMaxTokens() );
 	}
+
+	/**
+	 * Tests that is_supported returns false when prevent prompt filter returns true.
+	 *
+	 * @return void
+	 */
+	public function test_is_supported_returns_false_when_filter_prevents_prompt(): void {
+		add_filter( 'wp_ai_client_prevent_prompt', '__return_true' );
+
+		$builder = new Prompt_Builder( AiClient::defaultRegistry(), 'Test prompt' );
+
+		$this->assertFalse( $builder->is_supported() );
+	}
+
+	/**
+	 * Tests that generate_result throws RuntimeException when prevent prompt filter returns true.
+	 *
+	 * @return void
+	 */
+	public function test_generate_result_throws_exception_when_filter_prevents_prompt(): void {
+		add_filter( 'wp_ai_client_prevent_prompt', '__return_true' );
+
+		$builder = new Prompt_Builder( AiClient::defaultRegistry(), 'Test prompt' );
+
+		$this->expectException( RuntimeException::class );
+		$this->expectExceptionMessage( 'Prompt execution was prevented by a filter.' );
+
+		$builder->generate_result();
+	}
+
+	/**
+	 * Tests that prevent prompt filter receives the builder instance.
+	 *
+	 * @return void
+	 */
+	public function test_prevent_prompt_filter_receives_builder_instance(): void {
+		$captured_builder = null;
+
+		add_filter(
+			'wp_ai_client_prevent_prompt',
+			static function ( $prevent, $builder ) use ( &$captured_builder ) {
+				$captured_builder = $builder;
+				return $prevent;
+			},
+			10,
+			2
+		);
+
+		$builder = new Prompt_Builder( AiClient::defaultRegistry(), 'Test prompt' );
+		$builder->is_supported();
+
+		$this->assertSame( $builder, $captured_builder );
+	}
+
+	/**
+	 * Tests that is_supported works normally when filter returns false (default).
+	 *
+	 * @return void
+	 */
+	public function test_is_supported_works_normally_when_filter_returns_false(): void {
+		add_filter( 'wp_ai_client_prevent_prompt', '__return_false' );
+
+		$builder = new Prompt_Builder( AiClient::defaultRegistry(), 'Test prompt' );
+
+		// Should delegate to underlying builder and return true for text generation support.
+		$this->assertTrue( $builder->is_supported_for_text_generation() );
+	}
 }

--- a/tests/phpunit/tests/Builders/Prompt_Builder_Tests.php
+++ b/tests/phpunit/tests/Builders/Prompt_Builder_Tests.php
@@ -13,6 +13,7 @@ use InvalidArgumentException;
 use PHPUnit\Framework\TestCase;
 use ReflectionClass;
 use RuntimeException;
+use WordPress\AI_Client\Builders\Exception\Prompt_Prevented_Exception;
 use WordPress\AI_Client\Builders\Prompt_Builder;
 use WordPress\AI_Client\PHPUnit\Includes\Mock_Model_Creation_Trait;
 use WordPress\AI_Client\PHPUnit\Includes\Test_Case;
@@ -2264,7 +2265,7 @@ class Prompt_Builder_Tests extends Test_Case {
 	}
 
 	/**
-	 * Tests that generate_result throws RuntimeException when prevent prompt filter returns true.
+	 * Tests that generate_result throws Prompt_Prevented_Exception when prevent prompt filter returns true.
 	 *
 	 * @return void
 	 */
@@ -2273,7 +2274,7 @@ class Prompt_Builder_Tests extends Test_Case {
 
 		$builder = new Prompt_Builder( AiClient::defaultRegistry(), 'Test prompt' );
 
-		$this->expectException( RuntimeException::class );
+		$this->expectException( Prompt_Prevented_Exception::class );
 		$this->expectExceptionMessage( 'Prompt execution was prevented by a filter.' );
 
 		$builder->generate_result();

--- a/tests/phpunit/tests/Builders/Prompt_Builder_With_WP_Error_Tests.php
+++ b/tests/phpunit/tests/Builders/Prompt_Builder_With_WP_Error_Tests.php
@@ -303,4 +303,53 @@ class Prompt_Builder_With_WP_Error_Tests extends Test_Case {
 
 		$this->assertSame( $registry, $registry_property->getValue( $wrapped_builder ), 'Wrapped builder should have the same registry' );
 	}
+
+	/**
+	 * Test that generate_result returns WP_Error when prevent prompt filter returns true.
+	 */
+	public function test_generate_result_returns_wp_error_when_filter_prevents_prompt(): void {
+		add_filter( 'wp_ai_client_prevent_prompt', '__return_true' );
+
+		$prompt_builder = new Prompt_Builder_With_WP_Error( AiClient::defaultRegistry(), 'Test prompt' );
+
+		$result = $prompt_builder->generate_result();
+
+		$this->assertInstanceOf( WP_Error::class, $result );
+		$this->assertSame( 'prompt_prevented', $result->get_error_code() );
+		$this->assertSame( 'Prompt execution was prevented by a filter.', $result->get_error_message() );
+	}
+
+	/**
+	 * Test that is_supported returns false when prevent prompt filter returns true.
+	 */
+	public function test_is_supported_returns_false_when_filter_prevents_prompt(): void {
+		add_filter( 'wp_ai_client_prevent_prompt', '__return_true' );
+
+		$prompt_builder = new Prompt_Builder_With_WP_Error( AiClient::defaultRegistry(), 'Test prompt' );
+
+		$this->assertFalse( $prompt_builder->is_supported() );
+	}
+
+	/**
+	 * Test that prevent prompt filter receives the correct builder instance.
+	 */
+	public function test_prevent_prompt_filter_receives_wp_error_builder_instance(): void {
+		$captured_builder = null;
+
+		add_filter(
+			'wp_ai_client_prevent_prompt',
+			static function ( $prevent, $builder ) use ( &$captured_builder ) {
+				$captured_builder = $builder;
+				return $prevent;
+			},
+			10,
+			2
+		);
+
+		$prompt_builder = new Prompt_Builder_With_WP_Error( AiClient::defaultRegistry(), 'Test prompt' );
+		$prompt_builder->generate_result();
+
+		$this->assertSame( $prompt_builder, $captured_builder );
+		$this->assertInstanceOf( Prompt_Builder_With_WP_Error::class, $captured_builder );
+	}
 }

--- a/tests/phpunit/tests/Builders/Prompt_Builder_With_WP_Error_Tests.php
+++ b/tests/phpunit/tests/Builders/Prompt_Builder_With_WP_Error_Tests.php
@@ -133,16 +133,21 @@ class Prompt_Builder_With_WP_Error_Tests extends Test_Case {
 	}
 
 	/**
-	 * Test that calling a non-existent method throws an exception.
+	 * Test that calling a non-existent method returns WP_Error.
 	 */
-	public function test_invalid_method_throws_exception(): void {
+	public function test_invalid_method_returns_wp_error(): void {
 		$registry       = AiClient::defaultRegistry();
 		$prompt_builder = new Prompt_Builder_With_WP_Error( $registry );
 
-		$this->expectException( BadMethodCallException::class );
-		$this->expectExceptionMessage( 'Method non_existent_method does not exist' );
+		// Invalid method call should store error but return $this for chaining.
+		$result = $prompt_builder->non_existent_method();
+		$this->assertSame( $prompt_builder, $result );
 
-		$prompt_builder->non_existent_method();
+		// Calling a terminate method should return the stored WP_Error.
+		$result = $prompt_builder->generate_text();
+		$this->assertInstanceOf( WP_Error::class, $result );
+		$this->assertSame( 'prompt_builder_error', $result->get_error_code() );
+		$this->assertStringContainsString( 'non_existent_method does not exist', $result->get_error_message() );
 	}
 
 	/**

--- a/tests/phpunit/tests/Builders/Prompt_Builder_With_WP_Error_Tests.php
+++ b/tests/phpunit/tests/Builders/Prompt_Builder_With_WP_Error_Tests.php
@@ -336,9 +336,9 @@ class Prompt_Builder_With_WP_Error_Tests extends Test_Case {
 	}
 
 	/**
-	 * Test that prevent prompt filter receives the correct builder instance.
+	 * Test that prevent prompt filter receives a clone of the builder instance.
 	 */
-	public function test_prevent_prompt_filter_receives_wp_error_builder_instance(): void {
+	public function test_prevent_prompt_filter_receives_cloned_wp_error_builder_instance(): void {
 		$captured_builder = null;
 
 		add_filter(
@@ -354,7 +354,7 @@ class Prompt_Builder_With_WP_Error_Tests extends Test_Case {
 		$prompt_builder = new Prompt_Builder_With_WP_Error( AiClient::defaultRegistry(), 'Test prompt' );
 		$prompt_builder->generate_result();
 
-		$this->assertSame( $prompt_builder, $captured_builder );
+		$this->assertNotSame( $prompt_builder, $captured_builder, 'Filter should receive a clone, not the same instance' );
 		$this->assertInstanceOf( Prompt_Builder_With_WP_Error::class, $captured_builder );
 	}
 }


### PR DESCRIPTION
Depends on #46 
Resolves #38 

This introduces a way for developers to control, restrict, and even entirely disable AI by introducing the `wp_ai_client_prevent_prompt` boolean filter. If `true` is returned then `is_supported()` methods return `false` and generating methods will either thrown an exception or return a `WP_Error` depending on which builder is being used.

At this point, this is likely to be the control system that will make it into the core proposal. It's minimal but offers significant control, as well as a way for plugin developers to gracefully handle prevention using the `is_supported()` methods.