### PR TITLE
Force PHP 7.4 compatible version of `psr/simple-cache`

### DIFF
--- a/composer.json
+++ b/composer.json
@@ -36,6 +36,7 @@
         "php": ">=7.4",
         "ext-json": "*",
         "nyholm/psr7": "^1.5",
+        "psr/simple-cache": "^1.0",
         "wordpress/php-ai-client": "^0.4"
     },
     "require-dev": {

--- a/composer.lock
+++ b/composer.lock
@@ -4,7 +4,7 @@
         "Read more about it at https://getcomposer.org/doc/01-basic-usage.md#installing-dependencies",
         "This file is @generated automatically"
     ],
-    "content-hash": "a32cee75aedab7a3026000216d4eedfd",
+    "content-hash": "5b96de386f82a0c2634866387225934e",
     "packages": [
         {
             "name": "nyholm/psr7",


### PR DESCRIPTION
Fixes #50

* explicitly disallow any version other than `1.x`
* I audited the other prod dependencies, all of them are PHP 7.4 and PHP 8+ compatible in their latest version; so we only need this here