### PR TITLE
Register AI providers on init

### DIFF
--- a/composer.json
+++ b/composer.json
@@ -1,73 +1,76 @@
 {
-    "name": "wordpress/wp-ai-client",
-    "description": "An AI client and API for WordPress to communicate with any generative AI models of various capabilities using a uniform API.",
-    "license": "GPL-2.0-or-later",
-    "type": "library",
-    "keywords": [
-        "ai",
-        "api",
-        "llm",
-        "wordpress"
-    ],
-    "authors": [
-        {
-            "name": "WordPress AI Team",
-            "homepage": "https://make.wordpress.org/ai/"
-        }
-    ],
-    "homepage": "https://github.com/WordPress/wp-ai-client",
-    "support": {
-        "issues": "https://github.com/WordPress/wp-ai-client/issues",
-        "source": "https://github.com/WordPress/wp-ai-client"
-    },
-    "autoload": {
-        "psr-4": {
-            "WordPress\\AI_Client\\": "includes/"
-        }
-    },
-    "autoload-dev": {
-        "psr-4": {
-            "WordPress\\AI_Client\\PHPUnit\\Includes\\": "tests/phpunit/includes"
-        }
-    },
-    "minimum-stability": "dev",
-    "prefer-stable": true,
-    "require": {
-        "php": ">=7.4",
-        "ext-json": "*",
-        "nyholm/psr7": "^1.5",
-        "psr/simple-cache": "^1.0",
-        "wordpress/php-ai-client": "^1.0"
-    },
-    "require-dev": {
-        "automattic/vipwpcs": "^3.0",
-        "dealerdirect/phpcodesniffer-composer-installer": "^1.0",
-        "phpcompatibility/phpcompatibility-wp": "^2.1",
-        "phpstan/phpstan": "^1.10 | ^2.1",
-        "slevomat/coding-standard": "^8.0",
-        "squizlabs/php_codesniffer": "^3.7",
-        "szepeviktor/phpstan-wordpress": "^2.0",
-        "wp-coding-standards/wpcs": "^3.0",
-        "wp-phpunit/wp-phpunit": "^6.8",
-        "yoast/phpunit-polyfills": "^4.0"
-    },
-    "config": {
-        "allow-plugins": {
-            "composer/installers": true,
-            "php-http/discovery": true,
-            "dealerdirect/phpcodesniffer-composer-installer": true
-        },
-        "platform": {
-            "php": "7.4"
-        }
-    },
-    "scripts": {
-        "lint": [
-            "@phpcs",
-            "@phpstan"
-        ],
-        "phpcs": "phpcs",
-        "phpcbf": "phpcbf",
-        "phpstan": "phpstan analyze --memory-limit=1024M"
-    }
+	"name": "wordpress/wp-ai-client",
+	"description": "An AI client and API for WordPress to communicate with any generative AI models of various capabilities using a uniform API.",
+	"license": "GPL-2.0-or-later",
+	"type": "library",
+	"keywords": [
+		"ai",
+		"api",
+		"llm",
+		"wordpress"
+	],
+	"authors": [
+		{
+			"name": "WordPress AI Team",
+			"homepage": "https://make.wordpress.org/ai/"
+		}
+	],
+	"homepage": "https://github.com/WordPress/wp-ai-client",
+	"support": {
+		"issues": "https://github.com/WordPress/wp-ai-client/issues",
+		"source": "https://github.com/WordPress/wp-ai-client"
+	},
+	"autoload": {
+		"psr-4": {
+			"WordPress\\AI_Client\\": "includes/"
+		}
+	},
+	"autoload-dev": {
+		"psr-4": {
+			"WordPress\\AI_Client\\PHPUnit\\Includes\\": "tests/phpunit/includes"
+		}
+	},
+	"minimum-stability": "dev",
+	"prefer-stable": true,
+	"require": {
+		"php": ">=7.4",
+		"ext-json": "*",
+		"nyholm/psr7": "^1.5",
+		"psr/simple-cache": "^1.0",
+		"wordpress/php-ai-client": "^1.0",
+		"wordpress/openai-ai-provider": "^1.0",
+		"wordpress/google-ai-provider": "^1.0",
+		"wordpress/anthropic-ai-provider": "^1.0"
+	},
+	"require-dev": {
+		"automattic/vipwpcs": "^3.0",
+		"dealerdirect/phpcodesniffer-composer-installer": "^1.0",
+		"phpcompatibility/phpcompatibility-wp": "^2.1",
+		"phpstan/phpstan": "^1.10 | ^2.1",
+		"slevomat/coding-standard": "^8.0",
+		"squizlabs/php_codesniffer": "^3.7",
+		"szepeviktor/phpstan-wordpress": "^2.0",
+		"wp-coding-standards/wpcs": "^3.0",
+		"wp-phpunit/wp-phpunit": "^6.8",
+		"yoast/phpunit-polyfills": "^4.0"
+	},
+	"config": {
+		"allow-plugins": {
+			"composer/installers": true,
+			"php-http/discovery": true,
+			"dealerdirect/phpcodesniffer-composer-installer": true
+		},
+		"platform": {
+			"php": "7.4"
+		}
+	},
+	"scripts": {
+		"lint": [
+			"@phpcs",
+			"@phpstan"
+		],
+		"phpcs": "phpcs",
+		"phpcbf": "phpcbf",
+		"phpstan": "phpstan analyze --memory-limit=1024M"
+	}
 }

--- a/composer.lock
+++ b/composer.lock
@@ -4,7 +4,7 @@
         "Read more about it at https://getcomposer.org/doc/01-basic-usage.md#installing-dependencies",
         "This file is @generated automatically"
     ],
-    "content-hash": "0e9bc6106da8532d1a1e9c3cc1bda1bc",
+    "content-hash": "42eead9d7d6735b5a7a54dd711269fbd",
     "packages": [
         {
             "name": "nyholm/psr7",
@@ -534,21 +534,199 @@
             "time": "2017-10-23T01:57:42+00:00"
         },
         {
-            "name": "wordpress/php-ai-client",
+            "name": "wordpress/anthropic-ai-provider",
             "version": "1.0.0",
             "source": {
                 "type": "git",
-                "url": "https://github.com/WordPress/php-ai-client.git",
-                "reference": "0d688a1bbc27ae2675c8ed1c020af453d559bac5"
+                "url": "https://github.com/WordPress/anthropic-ai-provider.git",
+                "reference": "7abfab9d10f13c2c713484e3f5f096f81ad84b61"
             },
             "dist": {
                 "type": "zip",
-                "url": "https://api.github.com/repos/WordPress/php-ai-client/zipball/0d688a1bbc27ae2675c8ed1c020af453d559bac5",
-                "reference": "0d688a1bbc27ae2675c8ed1c020af453d559bac5",
+                "url": "https://api.github.com/repos/WordPress/anthropic-ai-provider/zipball/7abfab9d10f13c2c713484e3f5f096f81ad84b61",
+                "reference": "7abfab9d10f13c2c713484e3f5f096f81ad84b61",
+                "shasum": ""
+            },
+            "require": {
+                "php": ">=7.4"
+            },
+            "require-dev": {
+                "dealerdirect/phpcodesniffer-composer-installer": "^1.0",
+                "phpcompatibility/php-compatibility": "dev-develop",
+                "phpstan/phpstan": "~2.1",
+                "slevomat/coding-standard": "^8.20",
+                "squizlabs/php_codesniffer": "^3.7 || ^4.0",
+                "wordpress/php-ai-client": "^0.4 || dev-trunk"
+            },
+            "suggest": {
+                "wordpress/php-ai-client": "Required. The core PHP AI Client SDK that this provider extends."
+            },
+            "type": "wordpress-plugin",
+            "autoload": {
+                "psr-4": {
+                    "WordPress\\AnthropicAiProvider\\": "src/"
+                }
+            },
+            "notification-url": "https://packagist.org/downloads/",
+            "license": [
+                "GPL-2.0-or-later"
+            ],
+            "authors": [
+                {
+                    "name": "WordPress AI Team",
+                    "homepage": "https://make.wordpress.org/ai/"
+                }
+            ],
+            "description": "Anthropic AI provider for the PHP AI Client SDK. Works as both a Composer package and WordPress plugin.",
+            "homepage": "https://github.com/WordPress/anthropic-ai-provider",
+            "keywords": [
+                "ai",
+                "anthropic",
+                "claude",
+                "llm",
+                "wordpress"
+            ],
+            "support": {
+                "issues": "https://github.com/WordPress/anthropic-ai-provider/issues",
+                "source": "https://github.com/WordPress/anthropic-ai-provider"
+            },
+            "time": "2026-02-12T05:24:09+00:00"
+        },
+        {
+            "name": "wordpress/google-ai-provider",
+            "version": "1.0.0",
+            "source": {
+                "type": "git",
+                "url": "https://github.com/WordPress/google-ai-provider.git",
+                "reference": "ce063b2f13e54e2b59c0501c5437d4d7ae049d17"
+            },
+            "dist": {
+                "type": "zip",
+                "url": "https://api.github.com/repos/WordPress/google-ai-provider/zipball/ce063b2f13e54e2b59c0501c5437d4d7ae049d17",
+                "reference": "ce063b2f13e54e2b59c0501c5437d4d7ae049d17",
+                "shasum": ""
+            },
+            "require": {
+                "php": ">=7.4"
+            },
+            "require-dev": {
+                "dealerdirect/phpcodesniffer-composer-installer": "^1.0",
+                "phpcompatibility/php-compatibility": "dev-develop",
+                "phpstan/phpstan": "~2.1",
+                "slevomat/coding-standard": "^8.20",
+                "squizlabs/php_codesniffer": "^3.7 || ^4.0",
+                "wordpress/php-ai-client": "^0.4 || dev-trunk"
+            },
+            "suggest": {
+                "wordpress/php-ai-client": "Required. The core PHP AI Client SDK that this provider extends."
+            },
+            "type": "wordpress-plugin",
+            "autoload": {
+                "psr-4": {
+                    "WordPress\\GoogleAiProvider\\": "src/"
+                }
+            },
+            "notification-url": "https://packagist.org/downloads/",
+            "license": [
+                "GPL-2.0-or-later"
+            ],
+            "authors": [
+                {
+                    "name": "WordPress AI Team",
+                    "homepage": "https://make.wordpress.org/ai/"
+                }
+            ],
+            "description": "Google AI provider for the PHP AI Client SDK. Works as both a Composer package and WordPress plugin.",
+            "homepage": "https://github.com/WordPress/google-ai-provider",
+            "keywords": [
+                "Gemini",
+                "ai",
+                "google",
+                "llm",
+                "wordpress"
+            ],
+            "support": {
+                "issues": "https://github.com/WordPress/google-ai-provider/issues",
+                "source": "https://github.com/WordPress/google-ai-provider"
+            },
+            "time": "2026-02-12T05:21:47+00:00"
+        },
+        {
+            "name": "wordpress/openai-ai-provider",
+            "version": "1.0.0",
+            "source": {
+                "type": "git",
+                "url": "https://github.com/WordPress/openai-ai-provider.git",
+                "reference": "5db93179e52e9b63ce94c2a339a9cf46d6d51a32"
+            },
+            "dist": {
+                "type": "zip",
+                "url": "https://api.github.com/repos/WordPress/openai-ai-provider/zipball/5db93179e52e9b63ce94c2a339a9cf46d6d51a32",
+                "reference": "5db93179e52e9b63ce94c2a339a9cf46d6d51a32",
+                "shasum": ""
+            },
+            "require": {
+                "php": ">=7.4"
+            },
+            "require-dev": {
+                "dealerdirect/phpcodesniffer-composer-installer": "^1.0",
+                "phpcompatibility/php-compatibility": "dev-develop",
+                "phpstan/phpstan": "~2.1",
+                "slevomat/coding-standard": "^8.20",
+                "squizlabs/php_codesniffer": "^3.7 || ^4.0",
+                "wordpress/php-ai-client": "^0.4 || dev-trunk"
+            },
+            "suggest": {
+                "wordpress/php-ai-client": "Required. The core PHP AI Client SDK that this provider extends."
+            },
+            "type": "wordpress-plugin",
+            "autoload": {
+                "psr-4": {
+                    "WordPress\\OpenAiAiProvider\\": "src/"
+                }
+            },
+            "notification-url": "https://packagist.org/downloads/",
+            "license": [
+                "GPL-2.0-or-later"
+            ],
+            "authors": [
+                {
+                    "name": "WordPress AI Team",
+                    "homepage": "https://make.wordpress.org/ai/"
+                }
+            ],
+            "description": "OpenAI provider for the PHP AI Client SDK. Works as both a Composer package and WordPress plugin.",
+            "homepage": "https://github.com/WordPress/openai-ai-provider",
+            "keywords": [
+                "ai",
+                "gpt",
+                "llm",
+                "openai",
+                "wordpress"
+            ],
+            "support": {
+                "issues": "https://github.com/WordPress/openai-ai-provider/issues",
+                "source": "https://github.com/WordPress/openai-ai-provider"
+            },
+            "time": "2026-02-12T05:23:02+00:00"
+        },
+        {
+            "name": "wordpress/php-ai-client",
+            "version": "1.1.0",
+            "source": {
+                "type": "git",
+                "url": "https://github.com/WordPress/php-ai-client.git",
+                "reference": "c23867f6eb79028eeda89c6dcfd4467aaa7df14f"
+            },
+            "dist": {
+                "type": "zip",
+                "url": "https://api.github.com/repos/WordPress/php-ai-client/zipball/c23867f6eb79028eeda89c6dcfd4467aaa7df14f",
+                "reference": "c23867f6eb79028eeda89c6dcfd4467aaa7df14f",
                 "shasum": ""
             },
             "require": {
                 "ext-json": "*",
+                "nyholm/psr7": "^1.8",
                 "php": ">=7.4",
                 "php-http/discovery": "^1.0",
                 "php-http/httplug": "^2.0",
@@ -608,7 +786,7 @@
                 "issues": "https://github.com/WordPress/php-ai-client/issues",
                 "source": "https://github.com/WordPress/php-ai-client"
             },
-            "time": "2026-02-16T22:56:42+00:00"
+            "time": "2026-02-20T06:40:54+00:00"
         }
     ],
     "packages-dev": [
@@ -1070,16 +1248,16 @@
         },
         {
             "name": "php-stubs/wordpress-stubs",
-            "version": "v6.9.0",
+            "version": "v6.9.1",
             "source": {
                 "type": "git",
                 "url": "https://github.com/php-stubs/wordpress-stubs.git",
-                "reference": "5171cb6650e6c583a96943fd6ea0dfa3e1089a8a"
+                "reference": "f12220f303e0d7c0844c0e5e957b0c3cee48d2f7"
             },
             "dist": {
                 "type": "zip",
-                "url": "https://api.github.com/repos/php-stubs/wordpress-stubs/zipball/5171cb6650e6c583a96943fd6ea0dfa3e1089a8a",
-                "reference": "5171cb6650e6c583a96943fd6ea0dfa3e1089a8a",
+                "url": "https://api.github.com/repos/php-stubs/wordpress-stubs/zipball/f12220f303e0d7c0844c0e5e957b0c3cee48d2f7",
+                "reference": "f12220f303e0d7c0844c0e5e957b0c3cee48d2f7",
                 "shasum": ""
             },
             "conflict": {
@@ -1090,9 +1268,10 @@
                 "nikic/php-parser": "^5.5",
                 "php": "^7.4 || ^8.0",
                 "php-stubs/generator": "^0.8.3",
-                "phpdocumentor/reflection-docblock": "^5.4.1",
+                "phpdocumentor/reflection-docblock": "^6.0",
                 "phpstan/phpstan": "^2.1",
                 "phpunit/phpunit": "^9.5",
+                "symfony/polyfill-php80": "*",
                 "szepeviktor/phpcs-psr-12-neutron-hybrid-ruleset": "^1.1.1",
                 "wp-coding-standards/wpcs": "3.1.0 as 2.3.0"
             },
@@ -1115,9 +1294,9 @@
             ],
             "support": {
                 "issues": "https://github.com/php-stubs/wordpress-stubs/issues",
-                "source": "https://github.com/php-stubs/wordpress-stubs/tree/v6.9.0"
+                "source": "https://github.com/php-stubs/wordpress-stubs/tree/v6.9.1"
             },
-            "time": "2025-12-03T23:06:24+00:00"
+            "time": "2026-02-03T19:29:21+00:00"
         },
         {
             "name": "phpcompatibility/php-compatibility",
@@ -1416,16 +1595,16 @@
         },
         {
             "name": "phpcsstandards/phpcsutils",
-            "version": "1.2.1",
+            "version": "1.2.2",
             "source": {
                 "type": "git",
                 "url": "https://github.com/PHPCSStandards/PHPCSUtils.git",
-                "reference": "d71128c702c180ca3b27c761b6773f883394f162"
+                "reference": "c216317e96c8b3f5932808f9b0f1f7a14e3bbf55"
             },
             "dist": {
                 "type": "zip",
-                "url": "https://api.github.com/repos/PHPCSStandards/PHPCSUtils/zipball/d71128c702c180ca3b27c761b6773f883394f162",
-                "reference": "d71128c702c180ca3b27c761b6773f883394f162",
+                "url": "https://api.github.com/repos/PHPCSStandards/PHPCSUtils/zipball/c216317e96c8b3f5932808f9b0f1f7a14e3bbf55",
+                "reference": "c216317e96c8b3f5932808f9b0f1f7a14e3bbf55",
                 "shasum": ""
             },
             "require": {
@@ -1505,20 +1684,20 @@
                     "type": "thanks_dev"
                 }
             ],
-            "time": "2025-11-17T12:58:33+00:00"
+            "time": "2025-12-08T14:27:58+00:00"
         },
         {
             "name": "phpstan/phpdoc-parser",
-            "version": "2.3.0",
+            "version": "2.3.2",
             "source": {
                 "type": "git",
                 "url": "https://github.com/phpstan/phpdoc-parser.git",
-                "reference": "1e0cd5370df5dd2e556a36b9c62f62e555870495"
+                "reference": "a004701b11273a26cd7955a61d67a7f1e525a45a"
             },
             "dist": {
                 "type": "zip",
-                "url": "https://api.github.com/repos/phpstan/phpdoc-parser/zipball/1e0cd5370df5dd2e556a36b9c62f62e555870495",
-                "reference": "1e0cd5370df5dd2e556a36b9c62f62e555870495",
+                "url": "https://api.github.com/repos/phpstan/phpdoc-parser/zipball/a004701b11273a26cd7955a61d67a7f1e525a45a",
+                "reference": "a004701b11273a26cd7955a61d67a7f1e525a45a",
                 "shasum": ""
             },
             "require": {
@@ -1550,17 +1729,17 @@
             "description": "PHPDoc parser with support for nullable, intersection and generic types",
             "support": {
                 "issues": "https://github.com/phpstan/phpdoc-parser/issues",
-                "source": "https://github.com/phpstan/phpdoc-parser/tree/2.3.0"
+                "source": "https://github.com/phpstan/phpdoc-parser/tree/2.3.2"
             },
-            "time": "2025-08-30T15:50:23+00:00"
+            "time": "2026-01-25T14:56:51+00:00"
         },
         {
             "name": "phpstan/phpstan",
-            "version": "2.1.33",
+            "version": "2.1.39",
             "dist": {
                 "type": "zip",
-                "url": "https://api.github.com/repos/phpstan/phpstan/zipball/9e800e6bee7d5bd02784d4c6069b48032d16224f",
-                "reference": "9e800e6bee7d5bd02784d4c6069b48032d16224f",
+                "url": "https://api.github.com/repos/phpstan/phpstan/zipball/c6f73a2af4cbcd99c931d0fb8f08548cc0fa8224",
+                "reference": "c6f73a2af4cbcd99c931d0fb8f08548cc0fa8224",
                 "shasum": ""
             },
             "require": {
@@ -1605,7 +1784,7 @@
                     "type": "github"
                 }
             ],
-            "time": "2025-12-05T10:24:31+00:00"
+            "time": "2026-02-11T14:48:56+00:00"
         },
         {
             "name": "phpunit/php-code-coverage",
@@ -1928,16 +2107,16 @@
         },
         {
             "name": "phpunit/phpunit",
-            "version": "9.6.31",
+            "version": "9.6.34",
             "source": {
                 "type": "git",
                 "url": "https://github.com/sebastianbergmann/phpunit.git",
-                "reference": "945d0b7f346a084ce5549e95289962972c4272e5"
+                "reference": "b36f02317466907a230d3aa1d34467041271ef4a"
             },
             "dist": {
                 "type": "zip",
-                "url": "https://api.github.com/repos/sebastianbergmann/phpunit/zipball/945d0b7f346a084ce5549e95289962972c4272e5",
-                "reference": "945d0b7f346a084ce5549e95289962972c4272e5",
+                "url": "https://api.github.com/repos/sebastianbergmann/phpunit/zipball/b36f02317466907a230d3aa1d34467041271ef4a",
+                "reference": "b36f02317466907a230d3aa1d34467041271ef4a",
                 "shasum": ""
             },
             "require": {
@@ -1959,7 +2138,7 @@
                 "phpunit/php-timer": "^5.0.3",
                 "sebastian/cli-parser": "^1.0.2",
                 "sebastian/code-unit": "^1.0.8",
-                "sebastian/comparator": "^4.0.9",
+                "sebastian/comparator": "^4.0.10",
                 "sebastian/diff": "^4.0.6",
                 "sebastian/environment": "^5.1.5",
                 "sebastian/exporter": "^4.0.8",
@@ -2011,7 +2190,7 @@
             "support": {
                 "issues": "https://github.com/sebastianbergmann/phpunit/issues",
                 "security": "https://github.com/sebastianbergmann/phpunit/security/policy",
-                "source": "https://github.com/sebastianbergmann/phpunit/tree/9.6.31"
+                "source": "https://github.com/sebastianbergmann/phpunit/tree/9.6.34"
             },
             "funding": [
                 {
@@ -2035,7 +2214,7 @@
                     "type": "tidelift"
                 }
             ],
-            "time": "2025-12-06T07:45:52+00:00"
+            "time": "2026-01-27T05:45:00+00:00"
         },
         {
             "name": "sebastian/cli-parser",
@@ -2206,16 +2385,16 @@
         },
         {
             "name": "sebastian/comparator",
-            "version": "4.0.9",
+            "version": "4.0.10",
             "source": {
                 "type": "git",
                 "url": "https://github.com/sebastianbergmann/comparator.git",
-                "reference": "67a2df3a62639eab2cc5906065e9805d4fd5dfc5"
+                "reference": "e4df00b9b3571187db2831ae9aada2c6efbd715d"
             },
             "dist": {
                 "type": "zip",
-                "url": "https://api.github.com/repos/sebastianbergmann/comparator/zipball/67a2df3a62639eab2cc5906065e9805d4fd5dfc5",
-                "reference": "67a2df3a62639eab2cc5906065e9805d4fd5dfc5",
+                "url": "https://api.github.com/repos/sebastianbergmann/comparator/zipball/e4df00b9b3571187db2831ae9aada2c6efbd715d",
+                "reference": "e4df00b9b3571187db2831ae9aada2c6efbd715d",
                 "shasum": ""
             },
             "require": {
@@ -2268,7 +2447,7 @@
             ],
             "support": {
                 "issues": "https://github.com/sebastianbergmann/comparator/issues",
-                "source": "https://github.com/sebastianbergmann/comparator/tree/4.0.9"
+                "source": "https://github.com/sebastianbergmann/comparator/tree/4.0.10"
             },
             "funding": [
                 {
@@ -2288,7 +2467,7 @@
                     "type": "tidelift"
                 }
             ],
-            "time": "2025-08-10T06:51:50+00:00"
+            "time": "2026-01-24T09:22:56+00:00"
         },
         {
             "name": "sebastian/complexity",
@@ -3429,16 +3608,16 @@
         },
         {
             "name": "wp-phpunit/wp-phpunit",
-            "version": "6.9.0",
+            "version": "6.9.1",
             "source": {
                 "type": "git",
                 "url": "https://github.com/wp-phpunit/wp-phpunit.git",
-                "reference": "448dc57a97c7225d2ac6271876682fca4c2ed340"
+                "reference": "15fd216bf6516670d8d07b938675925bfa5c15b0"
             },
             "dist": {
                 "type": "zip",
-                "url": "https://api.github.com/repos/wp-phpunit/wp-phpunit/zipball/448dc57a97c7225d2ac6271876682fca4c2ed340",
-                "reference": "448dc57a97c7225d2ac6271876682fca4c2ed340",
+                "url": "https://api.github.com/repos/wp-phpunit/wp-phpunit/zipball/15fd216bf6516670d8d07b938675925bfa5c15b0",
+                "reference": "15fd216bf6516670d8d07b938675925bfa5c15b0",
                 "shasum": ""
             },
             "type": "library",
@@ -3473,7 +3652,7 @@
                 "issues": "https://github.com/wp-phpunit/issues",
                 "source": "https://github.com/wp-phpunit/wp-phpunit"
             },
-            "time": "2025-12-03T01:19:46+00:00"
+            "time": "2026-02-04T01:48:23+00:00"
         },
         {
             "name": "yoast/phpunit-polyfills",
@@ -3541,14 +3720,14 @@
     ],
     "aliases": [],
     "minimum-stability": "dev",
-    "stability-flags": [],
+    "stability-flags": {},
     "prefer-stable": true,
     "prefer-lowest": false,
     "platform": {
         "php": ">=7.4",
         "ext-json": "*"
     },
-    "platform-dev": [],
+    "platform-dev": {},
     "platform-overrides": {
         "php": "7.4"
     },

--- a/includes/AI_Client.php
+++ b/includes/AI_Client.php
@@ -63,6 +63,18 @@ class AI_Client {
 		// Wire up the WordPress cache with the PHP AI Client SDK.
 		AiClient::setCache( new WordPress_Cache() );
 
+		// Register available AI providers from separate packages.
+		$registry = AiClient::defaultRegistry();
+		foreach ( array(
+			'WordPress\OpenAiAiProvider\Provider\OpenAiProvider',
+			'WordPress\GoogleAiProvider\Provider\GoogleProvider',
+			'WordPress\AnthropicAiProvider\Provider\AnthropicProvider',
+		) as $provider_class ) {
+			if ( class_exists( $provider_class ) ) {
+				$registry->registerProvider( $provider_class );
+			}
+		}
+
 		// Initialize capabilities.
 		add_filter( 'user_has_cap', array( Capabilities_Manager::class, 'grant_prompt_ai_to_administrators' ) );
 		add_filter( 'user_has_cap', array( Capabilities_Manager::class, 'grant_list_ai_providers_models_to_administrators' ) );

--- a/package-lock.json
+++ b/package-lock.json
@@ -5325,7 +5325,6 @@
 			"integrity": "sha512-DSLCOXhkvfS5WNNPbfn2KdICAmk8lLc+/PNvnPnF7gOdMZCxopXduqv0OQ13y/yA/zXTSikZZqVgybUxOEg6YQ==",
 			"dev": true,
 			"license": "MIT",
-			"peer": true,
 			"dependencies": {
 				"@types/node": "*"
 			}


### PR DESCRIPTION
The provider implementations for OpenAI, Google, and Anthropic were moved to their own packages in `php-ai-client v1.0`:

`wordpress/openai-ai-provider`
`wordpress/google-ai-provider`
`wordpress/anthropic-ai-provider`
It looks like `wp-ai-client` needs a couple of updates to work with this new structure:

The three provider packages need to be listed in `composer.json` so they get pulled in automatically.
`AI_Client::init()` needs to register each provider with the `ProviderRegistry` so they're available to the credentials manager.
Without these, `API_Credentials_Manager::collect_providers()` returns an empty array and the settings page at `/wp-admin/options-general.php?page=wp-ai-client` doesn't show any provider fields.

What this PR does:
1. Adds the three provider packages to require in `composer.json`
2. Registers providers during `init()` via `ProviderRegistry::registerProvider()`, guarded by `class_exists()` checks

Tested locally — settings page renders correctly after these changes.