### PR TITLE
Prepares for 7.0 compat and transition

### DIFF
--- a/.github/workflows/php-test.yml
+++ b/.github/workflows/php-test.yml
@@ -44,16 +44,16 @@ jobs:
         - '7.4'
         - '8.0'
         - '8.4'
-        wordpress: [ 'trunk' ]
+        wordpress: [ '6.9' ]
         multisite: [ false, true ]
         experimental: [false]
         include:
           - php: '8.4'
-            wordpress: 'trunk'
+            wordpress: '6.9'
             multisite: false
             experimental: true
           - php: '8.4'
-            wordpress: 'trunk'
+            wordpress: '6.9'
             multisite: true
             experimental: true
     env:

--- a/README.md
+++ b/README.md
@@ -1,6 +1,6 @@
 # WordPress AI Client
 
-> **Deprecated:** This package is deprecated in favor of the built-in AI client in WordPress 7.0+. If you are running WordPress 7.0 or later, the AI client is provided natively by core and this plugin is a no-op. See [UPGRADE.md](./UPGRADE.md) for migration details.
+> **Deprecated:** This package is deprecated in favor of the built-in AI client in WordPress 7.0+. On 7.0+, the PHP SDK infrastructure is disabled (core handles it natively), but the REST API endpoints and JavaScript API remain active since they are not yet in core. See [UPGRADE.md](./UPGRADE.md) for migration details.
 
 [_Part of the **AI Building Blocks for WordPress** initiative_](https://make.wordpress.org/ai/2025/07/17/ai-building-blocks)
 

--- a/README.md
+++ b/README.md
@@ -1,5 +1,7 @@
 # WordPress AI Client
 
+> **Deprecated:** This package is deprecated in favor of the built-in AI client in WordPress 7.0+. If you are running WordPress 7.0 or later, the AI client is provided natively by core and this plugin is a no-op. See [UPGRADE.md](./UPGRADE.md) for migration details.
+
 [_Part of the **AI Building Blocks for WordPress** initiative_](https://make.wordpress.org/ai/2025/07/17/ai-building-blocks)
 
 An AI client and API for WordPress to communicate with any generative AI models of various capabilities using a uniform API.
@@ -26,7 +28,7 @@ composer require wordpress/wp-ai-client
 
 ### 1. Initialize the Client
 
-You must initialize the client on the WordPress `init` hook. This sets up the HTTP client integration and registers the settings screen.
+You must initialize the client on the WordPress `init` hook. This sets up the HTTP client integration and registers the settings screen. If you are using this as a plugin, this is already handled for you in `plugin.php`.
 
 ```php
 add_action( 'init', array( 'WordPress\AI_Client\AI_Client', 'init' ) );
@@ -62,10 +64,12 @@ The SDK provides a fluent `Prompt_Builder` interface to construct and execute AI
 **PHP:**
 
 ```php
-use WordPress\AI_Client\AI_Client;
-
-$text = AI_Client::prompt( 'Write a haiku about WordPress.' )
+$text = wp_ai_client_prompt( 'Write a haiku about WordPress.' )
 	->generate_text();
+
+if ( is_wp_error( $text ) ) {
+	wp_die( $text->get_error_message() );
+}
 
 echo wp_kses_post( $text );
 ```
@@ -84,10 +88,12 @@ console.log( text );
 **PHP:**
 
 ```php
-use WordPress\AI_Client\AI_Client;
-
-$image_file = AI_Client::prompt( 'A futuristic WordPress logo in neon style' )
+$image_file = wp_ai_client_prompt( 'A futuristic WordPress logo in neon style' )
 	->generate_image();
+
+if ( is_wp_error( $image_file ) ) {
+	wp_die( $image_file->get_error_message() );
+}
 
 $data_uri = $image_file->getDataUri();
 
@@ -112,8 +118,6 @@ console.log( `<img src="${ dataUri }" alt="A futuristic WordPress logo in neon s
 **PHP:**
 
 ```php
-use WordPress\AI_Client\AI_Client;
-
 $schema = array(
 	'type'       => 'array',
 	'items'      => array(
@@ -126,10 +130,14 @@ $schema = array(
 	),
 );
 
-$json = AI_Client::prompt( 'List 5 popular WordPress plugins with their primary category.' )
+$json = wp_ai_client_prompt( 'List 5 popular WordPress plugins with their primary category.' )
 	->using_temperature( 0.2 ) // Lower temperature for more deterministic result.
 	->as_json_response( $schema )
 	->generate_text();
+
+if ( is_wp_error( $json ) ) {
+	wp_die( $json->get_error_message() );
+}
 
 // Output will be a JSON string adhering to the schema.
 $data = json_decode( $json, true );
@@ -164,10 +172,12 @@ const data = JSON.parse( json );
 **PHP:**
 
 ```php
-use WordPress\AI_Client\AI_Client;
-
-$images = AI_Client::prompt( 'Aerial shot of snowy plains, cinematic.' )
+$images = wp_ai_client_prompt( 'Aerial shot of snowy plains, cinematic.' )
 	->generate_images( 4 );
+
+if ( is_wp_error( $images ) ) {
+	wp_die( $images->get_error_message() );
+}
 
 foreach ( $images as $image_file ) {
 	echo '<img src="' . esc_url( $image_file->getDataUri() ) . '" alt="Aerial shot of snowy plains">';
@@ -190,12 +200,15 @@ for ( const imageFile of images ) {
 **PHP:**
 
 ```php
-use WordPress\AI_Client\AI_Client;
 use WordPress\AiClient\Messages\Enums\ModalityEnum;
 
-$result = AI_Client::prompt( 'Create a recipe for a chocolate cake and include photos for the steps.' )
+$result = wp_ai_client_prompt( 'Create a recipe for a chocolate cake and include photos for the steps.' )
 	->as_output_modalities( ModalityEnum::text(), ModalityEnum::image() )
 	->generate_result();
+
+if ( is_wp_error( $result ) ) {
+	wp_die( $result->get_error_message() );
+}
 
 // Iterate through the message parts.
 foreach ( $result->toMessage()->getParts() as $part ) {
@@ -241,9 +254,7 @@ Pass preferences as either a model ID string, or as an array of `[ provider_id, 
 **PHP:**
 
 ```php
-use WordPress\AI_Client\AI_Client;
-
-$summary = AI_Client::prompt( 'Summarize the history of the printing press.' )
+$summary = wp_ai_client_prompt( 'Summarize the history of the printing press.' )
 	->using_temperature( 0.1 )
 	->using_model_preference(
 		'claude-sonnet-4-5',
@@ -273,10 +284,9 @@ Enforcing a single specific model using `using_model()` restricts your feature t
 **PHP:**
 
 ```php
-use WordPress\AI_Client\AI_Client;
 use WordPress\AiClient\ProviderImplementations\Anthropic\AnthropicProvider as Anthropic;
 
-$text = AI_Client::prompt( 'Explain quantum computing in simple terms.' )
+$text = wp_ai_client_prompt( 'Explain quantum computing in simple terms.' )
 	->using_model( Anthropic::model( 'claude-sonnet-4-5' ) )
 	->generate_text();
 ```
@@ -298,9 +308,7 @@ This is always recommended, but especially crucial if you require the use of a s
 **PHP:**
 
 ```php
-use WordPress\AI_Client\AI_Client;
-
-$prompt = AI_Client::prompt( 'Explain quantum computing in simple terms.' )
+$prompt = wp_ai_client_prompt( 'Explain quantum computing in simple terms.' )
 	->using_temperature( 0.2 );
 
 if ( $prompt->is_supported_for_text_generation() ) {
@@ -331,32 +339,10 @@ Generally, using `is_supported_for_text_generation()` (or `is_supported_for_imag
 
 ## Error Handling
 
-In PHP, the SDK offers two ways to handle errors.
-
-### 1. Exception Based
-
-`AI_Client::prompt()` throws exceptions on failure.
-
-**PHP:**
+The `wp_ai_client_prompt()` function returns `WP_Error` on failure, following WordPress conventions.
 
 ```php
-try {
-	$text = AI_Client::prompt( 'Hello' )->generate_text();
-} catch ( \Exception $e ) {
-	wp_die( $e->getMessage() );
-}
-
-echo wp_kses_post( $text );
-```
-
-### 2. `WP_Error` Based
-
-`AI_Client::prompt_with_wp_error()` returns a `WP_Error` object on failure.
-
-> **Note:** This error handling mechanism is experimental. We are gathering feedback to decide whether the SDK should primarily focus on exceptions or `WP_Error` objects.
-
-```php
-$text = AI_Client::prompt_with_wp_error( 'Hello' )
+$text = wp_ai_client_prompt( 'Hello' )
 	->generate_text();
 
 if ( is_wp_error( $text ) ) {
@@ -366,11 +352,28 @@ if ( is_wp_error( $text ) ) {
 echo wp_kses_post( $text );
 ```
 
+### Exception-based (advanced)
+
+If you prefer exceptions, use `AI_Client::prompt()` directly.
+
+```php
+use WordPress\AI_Client\AI_Client;
+
+try {
+	$text = AI_Client::prompt( 'Hello' )->generate_text();
+} catch ( \Exception $e ) {
+	wp_die( $e->getMessage() );
+}
+
+echo wp_kses_post( $text );
+```
+
 ## Architecture
 
 This library is a WordPress-specific wrapper around the [PHP AI Client](https://github.com/WordPress/php-ai-client).
 
-*   **`WordPress\AI_Client\AI_Client`**: The main entry point.
+*   **`wp_ai_client_prompt()`**: The recommended entry point function. Returns a `Prompt_Builder_With_WP_Error`.
+*   **`WordPress\AI_Client\AI_Client`**: The class-based entry point (for advanced use cases).
 *   **`WordPress\AI_Client\Builders\Prompt_Builder`**: A fluent builder for constructing AI requests. It maps WordPress-style `snake_case` methods to the underlying SDK's `camelCase` methods.
 *   **`WordPress\AI_Client\Builders\Prompt_Builder_With_WP_Error`**: A wrapper around `Prompt_Builder` that catches exceptions and returns `WP_Error` objects.
 

--- a/UPGRADE.md
+++ b/UPGRADE.md
@@ -1,0 +1,48 @@
+# Upgrading to WordPress 7.0
+
+WordPress 7.0 includes a built-in AI client, making this plugin unnecessary. When running on WordPress 7.0 or later, this plugin automatically becomes a no-op and core handles everything natively.
+
+## New standard entry point: `wp_ai_client_prompt()`
+
+The `wp_ai_client_prompt()` function is the standard entry point for the WordPress AI Client API. It is available both in this plugin (for WordPress < 7.0) and in WordPress core (7.0+).
+
+```php
+$text = wp_ai_client_prompt( 'Write a haiku about WordPress.' )
+	->generate_text();
+
+if ( is_wp_error( $text ) ) {
+	wp_die( $text->get_error_message() );
+}
+
+echo wp_kses_post( $text );
+```
+
+This function returns a prompt builder that uses `WP_Error` for error handling, following WordPress conventions.
+
+## Deprecated APIs
+
+The following APIs from this plugin do **not** exist in WordPress core:
+
+- **`AI_Client::prompt()`** - Use `wp_ai_client_prompt()` instead. The core equivalent returns `WP_Error` on failure rather than throwing exceptions.
+- **`AI_Client::prompt_with_wp_error()`** - Use `wp_ai_client_prompt()` instead. This was the precursor to the core function.
+- **`AI_Client::init()`** - No longer needed. Core initializes the AI client automatically.
+
+The `WordPress\AI_Client\AI_Client` class should not be used going forward. It is not available in WordPress core.
+
+## Behavior on WordPress 7.0+
+
+When this plugin detects WordPress 7.0 or later, it returns early during loading and does not:
+
+- Register any autoloader.
+- Register any hooks, settings screens, or REST API routes.
+- Define `wp_ai_client_prompt()` (core already provides it).
+
+This means you can safely leave the plugin installed during the transition period without any conflicts.
+
+## Migration checklist
+
+1. Replace all `AI_Client::prompt()` calls with `wp_ai_client_prompt()` and handle `WP_Error` returns.
+2. Replace all `AI_Client::prompt_with_wp_error()` calls with `wp_ai_client_prompt()`.
+3. Remove any `AI_Client::init()` calls (or the `add_action( 'init', ... )` hook).
+4. Remove the `use WordPress\AI_Client\AI_Client;` import statements.
+5. Once your site runs WordPress 7.0+, deactivate and remove this plugin.

--- a/UPGRADE.md
+++ b/UPGRADE.md
@@ -1,10 +1,10 @@
 # Upgrading to WordPress 7.0
 
-WordPress 7.0 includes a built-in AI client, making this plugin unnecessary. When running on WordPress 7.0 or later, this plugin automatically becomes a no-op and core handles everything natively.
+WordPress 7.0 includes a built-in AI client. When running on WordPress 7.0 or later, the package disables its PHP SDK infrastructure (core handles it natively) but keeps the REST API endpoints and JavaScript API active, since those are not yet in core.
 
 ## New standard entry point: `wp_ai_client_prompt()`
 
-The `wp_ai_client_prompt()` function is the standard entry point for the WordPress AI Client API. It is available both in this plugin (for WordPress < 7.0) and in WordPress core (7.0+).
+The `wp_ai_client_prompt()` function is the standard entry point for the WordPress AI Client API. It is available both in this package (for WordPress < 7.0) and in WordPress core (7.0+).
 
 ```php
 $text = wp_ai_client_prompt( 'Write a haiku about WordPress.' )
@@ -21,7 +21,7 @@ This function returns a prompt builder that uses `WP_Error` for error handling, 
 
 ## Deprecated APIs
 
-The following APIs from this plugin do **not** exist in WordPress core:
+The following APIs from this package do **not** exist in WordPress core:
 
 - **`AI_Client::prompt()`** - Use `wp_ai_client_prompt()` instead. The core equivalent returns `WP_Error` on failure rather than throwing exceptions.
 - **`AI_Client::prompt_with_wp_error()`** - Use `wp_ai_client_prompt()` instead. This was the precursor to the core function.
@@ -31,13 +31,17 @@ The `WordPress\AI_Client\AI_Client` class should not be used going forward. It i
 
 ## Behavior on WordPress 7.0+
 
-When this plugin detects WordPress 7.0 or later, it returns early during loading and does not:
+When this package detects WordPress 7.0 or later, it disables its PHP SDK infrastructure (HTTP client wiring, event dispatcher, cache, and API credentials settings screen), since core handles all of that natively.
 
-- Register any autoloader.
-- Register any hooks, settings screens, or REST API routes.
-- Define `wp_ai_client_prompt()` (core already provides it).
+The following remain active on all WordPress versions:
 
-This means you can safely leave the plugin installed during the transition period without any conflicts.
+- **REST API endpoints** (`/wp-ai/v1/generate`, `/wp-ai/v1/is-supported`) — these delegate to `wp_ai_client_prompt()`, so they naturally use core's AI client on 7.0+.
+- **Client-side JavaScript API** (`wp-ai-client` script) — not yet available in core.
+- **Capability filters** (`prompt_ai`, `list_ai_providers_models`) — idempotent with core.
+
+The package does not define `wp_ai_client_prompt()` on 7.0+ (core already provides it).
+
+This means you can safely keep the package installed as a dependency during the transition period without any conflicts.
 
 ## Migration checklist
 
@@ -45,4 +49,4 @@ This means you can safely leave the plugin installed during the transition perio
 2. Replace all `AI_Client::prompt_with_wp_error()` calls with `wp_ai_client_prompt()`.
 3. Remove any `AI_Client::init()` calls (or the `add_action( 'init', ... )` hook).
 4. Remove the `use WordPress\AI_Client\AI_Client;` import statements.
-5. Once your site runs WordPress 7.0+, deactivate and remove this plugin.
+5. Once your site runs WordPress 7.0+, remove this package from your dependencies.

--- a/autoload.php
+++ b/autoload.php
@@ -13,7 +13,13 @@ require_once __DIR__ . '/functions.php';
 if ( ! wp_has_ai_client() ) {
 	// On < 7.0, load the full Composer autoloader (PHP AI Client SDK, PSR
 	// packages, and this plugin's own classes).
-	require_once __DIR__ . '/vendor/autoload.php';
+	if ( file_exists( __DIR__ . '/vendor/autoload.php' ) ) {
+		// Load autoload.php file from this package.
+		require_once __DIR__ . '/vendor/autoload.php';
+	} else {
+		// Load autoload.php file from parent package that bundles this one.
+		require_once dirname( __DIR__, 2 ) . '/autoload.php';
+	}
 } else {
 	// On 7.0+, only autoload this plugin's own classes. Core provides the
 	// AI client SDK natively with scoped PSR dependencies; loading this

--- a/autoload.php
+++ b/autoload.php
@@ -1,0 +1,36 @@
+<?php
+/**
+ * Custom autoloader for the WordPress AI Client package.
+ *
+ * Plugins that bundle this package should load this file instead of the Composer autoloader, to avoid conflicts with
+ * core's own bundled version of the PHP AI Client SDK and its dependencies on WordPress 7.0+.
+ *
+ * @package WordPress\AI_Client
+ */
+
+require_once __DIR__ . '/functions.php';
+
+if ( ! wp_has_ai_client() ) {
+	// On < 7.0, load the full Composer autoloader (PHP AI Client SDK, PSR
+	// packages, and this plugin's own classes).
+	require_once __DIR__ . '/vendor/autoload.php';
+} else {
+	// On 7.0+, only autoload this plugin's own classes. Core provides the
+	// AI client SDK natively with scoped PSR dependencies; loading this
+	// plugin's vendor autoloader would cause fatal declaration-compatibility
+	// errors between unscoped PSR types and core's scoped versions.
+	spl_autoload_register(
+		static function ( $class ) {
+			$prefix = 'WordPress\\AI_Client\\';
+			$len    = strlen( $prefix );
+			if ( strncmp( $class, $prefix, $len ) !== 0 ) {
+				return;
+			}
+			$relative_class = substr( $class, $len );
+			$file           = __DIR__ . '/includes/' . str_replace( '\\', '/', $relative_class ) . '.php';
+			if ( file_exists( $file ) ) {
+				require $file;
+			}
+		}
+	);
+}

--- a/composer.json
+++ b/composer.json
@@ -36,7 +36,7 @@
         "php": ">=7.4",
         "ext-json": "*",
         "psr/simple-cache": "^1.0",
-        "wordpress/php-ai-client": "^1.1"
+        "wordpress/php-ai-client": "^1.2"
     },
     "require-dev": {
         "automattic/vipwpcs": "^3.0",

--- a/composer.json
+++ b/composer.json
@@ -21,6 +21,9 @@
         "source": "https://github.com/WordPress/wp-ai-client"
     },
     "autoload": {
+        "files": [
+            "functions.php"
+        ],
         "psr-4": {
             "WordPress\\AI_Client\\": "includes/"
         }

--- a/composer.json
+++ b/composer.json
@@ -35,9 +35,8 @@
     "require": {
         "php": ">=7.4",
         "ext-json": "*",
-        "nyholm/psr7": "^1.5",
         "psr/simple-cache": "^1.0",
-        "wordpress/php-ai-client": "^1.0"
+        "wordpress/php-ai-client": "^1.1"
     },
     "require-dev": {
         "automattic/vipwpcs": "^3.0",

--- a/composer.lock
+++ b/composer.lock
@@ -4,7 +4,7 @@
         "Read more about it at https://getcomposer.org/doc/01-basic-usage.md#installing-dependencies",
         "This file is @generated automatically"
     ],
-    "content-hash": "2202983775c0114e484ab8830bfe00ff",
+    "content-hash": "d0aacce8f178f9d0d4746d90ffcf06b4",
     "packages": [
         {
             "name": "nyholm/psr7",
@@ -535,16 +535,16 @@
         },
         {
             "name": "wordpress/php-ai-client",
-            "version": "1.1.0",
+            "version": "1.2.0",
             "source": {
                 "type": "git",
                 "url": "https://github.com/WordPress/php-ai-client.git",
-                "reference": "c23867f6eb79028eeda89c6dcfd4467aaa7df14f"
+                "reference": "eb1241fa10e580726e49ae800afd18da16864ec0"
             },
             "dist": {
                 "type": "zip",
-                "url": "https://api.github.com/repos/WordPress/php-ai-client/zipball/c23867f6eb79028eeda89c6dcfd4467aaa7df14f",
-                "reference": "c23867f6eb79028eeda89c6dcfd4467aaa7df14f",
+                "url": "https://api.github.com/repos/WordPress/php-ai-client/zipball/eb1241fa10e580726e49ae800afd18da16864ec0",
+                "reference": "eb1241fa10e580726e49ae800afd18da16864ec0",
                 "shasum": ""
             },
             "require": {
@@ -609,7 +609,7 @@
                 "issues": "https://github.com/WordPress/php-ai-client/issues",
                 "source": "https://github.com/WordPress/php-ai-client"
             },
-            "time": "2026-02-20T06:40:54+00:00"
+            "time": "2026-02-27T02:45:23+00:00"
         }
     ],
     "packages-dev": [

--- a/composer.lock
+++ b/composer.lock
@@ -4,7 +4,7 @@
         "Read more about it at https://getcomposer.org/doc/01-basic-usage.md#installing-dependencies",
         "This file is @generated automatically"
     ],
-    "content-hash": "0e9bc6106da8532d1a1e9c3cc1bda1bc",
+    "content-hash": "2202983775c0114e484ab8830bfe00ff",
     "packages": [
         {
             "name": "nyholm/psr7",
@@ -535,20 +535,21 @@
         },
         {
             "name": "wordpress/php-ai-client",
-            "version": "1.0.0",
+            "version": "1.1.0",
             "source": {
                 "type": "git",
                 "url": "https://github.com/WordPress/php-ai-client.git",
-                "reference": "0d688a1bbc27ae2675c8ed1c020af453d559bac5"
+                "reference": "c23867f6eb79028eeda89c6dcfd4467aaa7df14f"
             },
             "dist": {
                 "type": "zip",
-                "url": "https://api.github.com/repos/WordPress/php-ai-client/zipball/0d688a1bbc27ae2675c8ed1c020af453d559bac5",
-                "reference": "0d688a1bbc27ae2675c8ed1c020af453d559bac5",
+                "url": "https://api.github.com/repos/WordPress/php-ai-client/zipball/c23867f6eb79028eeda89c6dcfd4467aaa7df14f",
+                "reference": "c23867f6eb79028eeda89c6dcfd4467aaa7df14f",
                 "shasum": ""
             },
             "require": {
                 "ext-json": "*",
+                "nyholm/psr7": "^1.8",
                 "php": ">=7.4",
                 "php-http/discovery": "^1.0",
                 "php-http/httplug": "^2.0",
@@ -608,7 +609,7 @@
                 "issues": "https://github.com/WordPress/php-ai-client/issues",
                 "source": "https://github.com/WordPress/php-ai-client"
             },
-            "time": "2026-02-16T22:56:42+00:00"
+            "time": "2026-02-20T06:40:54+00:00"
         }
     ],
     "packages-dev": [
@@ -1070,16 +1071,16 @@
         },
         {
             "name": "php-stubs/wordpress-stubs",
-            "version": "v6.9.0",
+            "version": "v6.9.1",
             "source": {
                 "type": "git",
                 "url": "https://github.com/php-stubs/wordpress-stubs.git",
-                "reference": "5171cb6650e6c583a96943fd6ea0dfa3e1089a8a"
+                "reference": "f12220f303e0d7c0844c0e5e957b0c3cee48d2f7"
             },
             "dist": {
                 "type": "zip",
-                "url": "https://api.github.com/repos/php-stubs/wordpress-stubs/zipball/5171cb6650e6c583a96943fd6ea0dfa3e1089a8a",
-                "reference": "5171cb6650e6c583a96943fd6ea0dfa3e1089a8a",
+                "url": "https://api.github.com/repos/php-stubs/wordpress-stubs/zipball/f12220f303e0d7c0844c0e5e957b0c3cee48d2f7",
+                "reference": "f12220f303e0d7c0844c0e5e957b0c3cee48d2f7",
                 "shasum": ""
             },
             "conflict": {
@@ -1090,9 +1091,10 @@
                 "nikic/php-parser": "^5.5",
                 "php": "^7.4 || ^8.0",
                 "php-stubs/generator": "^0.8.3",
-                "phpdocumentor/reflection-docblock": "^5.4.1",
+                "phpdocumentor/reflection-docblock": "^6.0",
                 "phpstan/phpstan": "^2.1",
                 "phpunit/phpunit": "^9.5",
+                "symfony/polyfill-php80": "*",
                 "szepeviktor/phpcs-psr-12-neutron-hybrid-ruleset": "^1.1.1",
                 "wp-coding-standards/wpcs": "3.1.0 as 2.3.0"
             },
@@ -1115,9 +1117,9 @@
             ],
             "support": {
                 "issues": "https://github.com/php-stubs/wordpress-stubs/issues",
-                "source": "https://github.com/php-stubs/wordpress-stubs/tree/v6.9.0"
+                "source": "https://github.com/php-stubs/wordpress-stubs/tree/v6.9.1"
             },
-            "time": "2025-12-03T23:06:24+00:00"
+            "time": "2026-02-03T19:29:21+00:00"
         },
         {
             "name": "phpcompatibility/php-compatibility",
@@ -1416,16 +1418,16 @@
         },
         {
             "name": "phpcsstandards/phpcsutils",
-            "version": "1.2.1",
+            "version": "1.2.2",
             "source": {
                 "type": "git",
                 "url": "https://github.com/PHPCSStandards/PHPCSUtils.git",
-                "reference": "d71128c702c180ca3b27c761b6773f883394f162"
+                "reference": "c216317e96c8b3f5932808f9b0f1f7a14e3bbf55"
             },
             "dist": {
                 "type": "zip",
-                "url": "https://api.github.com/repos/PHPCSStandards/PHPCSUtils/zipball/d71128c702c180ca3b27c761b6773f883394f162",
-                "reference": "d71128c702c180ca3b27c761b6773f883394f162",
+                "url": "https://api.github.com/repos/PHPCSStandards/PHPCSUtils/zipball/c216317e96c8b3f5932808f9b0f1f7a14e3bbf55",
+                "reference": "c216317e96c8b3f5932808f9b0f1f7a14e3bbf55",
                 "shasum": ""
             },
             "require": {
@@ -1505,20 +1507,20 @@
                     "type": "thanks_dev"
                 }
             ],
-            "time": "2025-11-17T12:58:33+00:00"
+            "time": "2025-12-08T14:27:58+00:00"
         },
         {
             "name": "phpstan/phpdoc-parser",
-            "version": "2.3.0",
+            "version": "2.3.2",
             "source": {
                 "type": "git",
                 "url": "https://github.com/phpstan/phpdoc-parser.git",
-                "reference": "1e0cd5370df5dd2e556a36b9c62f62e555870495"
+                "reference": "a004701b11273a26cd7955a61d67a7f1e525a45a"
             },
             "dist": {
                 "type": "zip",
-                "url": "https://api.github.com/repos/phpstan/phpdoc-parser/zipball/1e0cd5370df5dd2e556a36b9c62f62e555870495",
-                "reference": "1e0cd5370df5dd2e556a36b9c62f62e555870495",
+                "url": "https://api.github.com/repos/phpstan/phpdoc-parser/zipball/a004701b11273a26cd7955a61d67a7f1e525a45a",
+                "reference": "a004701b11273a26cd7955a61d67a7f1e525a45a",
                 "shasum": ""
             },
             "require": {
@@ -1550,17 +1552,17 @@
             "description": "PHPDoc parser with support for nullable, intersection and generic types",
             "support": {
                 "issues": "https://github.com/phpstan/phpdoc-parser/issues",
-                "source": "https://github.com/phpstan/phpdoc-parser/tree/2.3.0"
+                "source": "https://github.com/phpstan/phpdoc-parser/tree/2.3.2"
             },
-            "time": "2025-08-30T15:50:23+00:00"
+            "time": "2026-01-25T14:56:51+00:00"
         },
         {
             "name": "phpstan/phpstan",
-            "version": "2.1.33",
+            "version": "2.1.40",
             "dist": {
                 "type": "zip",
-                "url": "https://api.github.com/repos/phpstan/phpstan/zipball/9e800e6bee7d5bd02784d4c6069b48032d16224f",
-                "reference": "9e800e6bee7d5bd02784d4c6069b48032d16224f",
+                "url": "https://api.github.com/repos/phpstan/phpstan/zipball/9b2c7aeb83a75d8680ea5e7c9b7fca88052b766b",
+                "reference": "9b2c7aeb83a75d8680ea5e7c9b7fca88052b766b",
                 "shasum": ""
             },
             "require": {
@@ -1605,7 +1607,7 @@
                     "type": "github"
                 }
             ],
-            "time": "2025-12-05T10:24:31+00:00"
+            "time": "2026-02-23T15:04:35+00:00"
         },
         {
             "name": "phpunit/php-code-coverage",
@@ -1928,16 +1930,16 @@
         },
         {
             "name": "phpunit/phpunit",
-            "version": "9.6.31",
+            "version": "9.6.34",
             "source": {
                 "type": "git",
                 "url": "https://github.com/sebastianbergmann/phpunit.git",
-                "reference": "945d0b7f346a084ce5549e95289962972c4272e5"
+                "reference": "b36f02317466907a230d3aa1d34467041271ef4a"
             },
             "dist": {
                 "type": "zip",
-                "url": "https://api.github.com/repos/sebastianbergmann/phpunit/zipball/945d0b7f346a084ce5549e95289962972c4272e5",
-                "reference": "945d0b7f346a084ce5549e95289962972c4272e5",
+                "url": "https://api.github.com/repos/sebastianbergmann/phpunit/zipball/b36f02317466907a230d3aa1d34467041271ef4a",
+                "reference": "b36f02317466907a230d3aa1d34467041271ef4a",
                 "shasum": ""
             },
             "require": {
@@ -1959,7 +1961,7 @@
                 "phpunit/php-timer": "^5.0.3",
                 "sebastian/cli-parser": "^1.0.2",
                 "sebastian/code-unit": "^1.0.8",
-                "sebastian/comparator": "^4.0.9",
+                "sebastian/comparator": "^4.0.10",
                 "sebastian/diff": "^4.0.6",
                 "sebastian/environment": "^5.1.5",
                 "sebastian/exporter": "^4.0.8",
@@ -2011,7 +2013,7 @@
             "support": {
                 "issues": "https://github.com/sebastianbergmann/phpunit/issues",
                 "security": "https://github.com/sebastianbergmann/phpunit/security/policy",
-                "source": "https://github.com/sebastianbergmann/phpunit/tree/9.6.31"
+                "source": "https://github.com/sebastianbergmann/phpunit/tree/9.6.34"
             },
             "funding": [
                 {
@@ -2035,7 +2037,7 @@
                     "type": "tidelift"
                 }
             ],
-            "time": "2025-12-06T07:45:52+00:00"
+            "time": "2026-01-27T05:45:00+00:00"
         },
         {
             "name": "sebastian/cli-parser",
@@ -2206,16 +2208,16 @@
         },
         {
             "name": "sebastian/comparator",
-            "version": "4.0.9",
+            "version": "4.0.10",
             "source": {
                 "type": "git",
                 "url": "https://github.com/sebastianbergmann/comparator.git",
-                "reference": "67a2df3a62639eab2cc5906065e9805d4fd5dfc5"
+                "reference": "e4df00b9b3571187db2831ae9aada2c6efbd715d"
             },
             "dist": {
                 "type": "zip",
-                "url": "https://api.github.com/repos/sebastianbergmann/comparator/zipball/67a2df3a62639eab2cc5906065e9805d4fd5dfc5",
-                "reference": "67a2df3a62639eab2cc5906065e9805d4fd5dfc5",
+                "url": "https://api.github.com/repos/sebastianbergmann/comparator/zipball/e4df00b9b3571187db2831ae9aada2c6efbd715d",
+                "reference": "e4df00b9b3571187db2831ae9aada2c6efbd715d",
                 "shasum": ""
             },
             "require": {
@@ -2268,7 +2270,7 @@
             ],
             "support": {
                 "issues": "https://github.com/sebastianbergmann/comparator/issues",
-                "source": "https://github.com/sebastianbergmann/comparator/tree/4.0.9"
+                "source": "https://github.com/sebastianbergmann/comparator/tree/4.0.10"
             },
             "funding": [
                 {
@@ -2288,7 +2290,7 @@
                     "type": "tidelift"
                 }
             ],
-            "time": "2025-08-10T06:51:50+00:00"
+            "time": "2026-01-24T09:22:56+00:00"
         },
         {
             "name": "sebastian/complexity",
@@ -3429,16 +3431,16 @@
         },
         {
             "name": "wp-phpunit/wp-phpunit",
-            "version": "6.9.0",
+            "version": "6.9.1",
             "source": {
                 "type": "git",
                 "url": "https://github.com/wp-phpunit/wp-phpunit.git",
-                "reference": "448dc57a97c7225d2ac6271876682fca4c2ed340"
+                "reference": "15fd216bf6516670d8d07b938675925bfa5c15b0"
             },
             "dist": {
                 "type": "zip",
-                "url": "https://api.github.com/repos/wp-phpunit/wp-phpunit/zipball/448dc57a97c7225d2ac6271876682fca4c2ed340",
-                "reference": "448dc57a97c7225d2ac6271876682fca4c2ed340",
+                "url": "https://api.github.com/repos/wp-phpunit/wp-phpunit/zipball/15fd216bf6516670d8d07b938675925bfa5c15b0",
+                "reference": "15fd216bf6516670d8d07b938675925bfa5c15b0",
                 "shasum": ""
             },
             "type": "library",
@@ -3473,7 +3475,7 @@
                 "issues": "https://github.com/wp-phpunit/issues",
                 "source": "https://github.com/wp-phpunit/wp-phpunit"
             },
-            "time": "2025-12-03T01:19:46+00:00"
+            "time": "2026-02-04T01:48:23+00:00"
         },
         {
             "name": "yoast/phpunit-polyfills",
@@ -3541,16 +3543,16 @@
     ],
     "aliases": [],
     "minimum-stability": "dev",
-    "stability-flags": [],
+    "stability-flags": {},
     "prefer-stable": true,
     "prefer-lowest": false,
     "platform": {
         "php": ">=7.4",
         "ext-json": "*"
     },
-    "platform-dev": [],
+    "platform-dev": {},
     "platform-overrides": {
         "php": "7.4"
     },
-    "plugin-api-version": "2.6.0"
+    "plugin-api-version": "2.9.0"
 }

--- a/functions.php
+++ b/functions.php
@@ -5,19 +5,21 @@
  * @package WordPress\AI_Client
  */
 
-/**
- * Checks whether the current WordPress version natively provides the AI client.
- *
- * @since n.e.x.t
- * @access private
- *
- * @return bool True if WordPress 7.0+ is present with a native AI client.
- */
-function wp_has_ai_client() {
-	return function_exists( 'wp_get_wp_version' ) && version_compare( wp_get_wp_version(), '7.0-alpha', '>=' );
+if ( ! function_exists( 'wp_has_ai_client' ) ) {
+	/**
+	 * Checks whether the current WordPress version natively provides the AI client.
+	 *
+	 * @since n.e.x.t
+	 * @access private
+	 *
+	 * @return bool True if WordPress 7.0+ is present with a native AI client.
+	 */
+	function wp_has_ai_client() {
+		return function_exists( 'wp_get_wp_version' ) && version_compare( wp_get_wp_version(), '7.0-alpha', '>=' );
+	}
 }
 
-if ( ! wp_has_ai_client() ) {
+if ( ! function_exists( 'wp_ai_client_prompt' ) ) {
 	/**
 	 * Creates a new AI prompt builder for fluent API usage, returning WP_Error on errors.
 	 *

--- a/functions.php
+++ b/functions.php
@@ -26,7 +26,7 @@ if ( ! wp_has_ai_client() ) {
 	 *
 	 * @since n.e.x.t
 	 *
-	 * @param string|null $prompt Optional initial prompt content.
+	 * @param string|array<int, mixed>|null $prompt Optional initial prompt content.
 	 * @return WordPress\AI_Client\Builders\Prompt_Builder_With_WP_Error The prompt builder instance.
 	 */
 	function wp_ai_client_prompt( $prompt = null ) {

--- a/functions.php
+++ b/functions.php
@@ -14,7 +14,7 @@
  * @return bool True if WordPress 7.0+ is present with a native AI client.
  */
 function wp_has_ai_client() {
-	return function_exists( 'wp_ai_client_prompt' );
+	return function_exists( 'wp_get_wp_version' ) && version_compare( wp_get_wp_version(), '7.0-alpha', '>=' );
 }
 
 if ( ! wp_has_ai_client() ) {

--- a/functions.php
+++ b/functions.php
@@ -5,7 +5,19 @@
  * @package WordPress\AI_Client
  */
 
-if ( ! function_exists( 'wp_ai_client_prompt' ) ) {
+/**
+ * Checks whether the current WordPress version natively provides the AI client.
+ *
+ * @since n.e.x.t
+ * @access private
+ *
+ * @return bool True if WordPress 7.0+ is present with a native AI client.
+ */
+function wp_has_ai_client() {
+	return function_exists( 'wp_ai_client_prompt' );
+}
+
+if ( ! wp_has_ai_client() ) {
 	/**
 	 * Creates a new AI prompt builder for fluent API usage, returning WP_Error on errors.
 	 *

--- a/functions.php
+++ b/functions.php
@@ -1,0 +1,23 @@
+<?php
+/**
+ * Global functions for the WordPress AI Client plugin.
+ *
+ * @package WordPress\AI_Client
+ */
+
+if ( ! function_exists( 'wp_ai_client_prompt' ) ) {
+	/**
+	 * Creates a new AI prompt builder for fluent API usage, returning WP_Error on errors.
+	 *
+	 * This is the standard entry point for the WordPress AI Client API. It mirrors
+	 * core's wp_ai_client_prompt() available in WordPress 7.0+.
+	 *
+	 * @since n.e.x.t
+	 *
+	 * @param string|null $prompt Optional initial prompt content.
+	 * @return WordPress\AI_Client\Builders\Prompt_Builder_With_WP_Error The prompt builder instance.
+	 */
+	function wp_ai_client_prompt( $prompt = null ) {
+		return new WordPress\AI_Client\Builders\Prompt_Builder_With_WP_Error( WordPress\AiClient\AiClient::defaultRegistry(), $prompt );
+	}
+}

--- a/functions.php
+++ b/functions.php
@@ -1,6 +1,6 @@
 <?php
 /**
- * Global functions for the WordPress AI Client plugin.
+ * Global functions for the WordPress AI Client package.
  *
  * @package WordPress\AI_Client
  */

--- a/includes/AI_Client.php
+++ b/includes/AI_Client.php
@@ -54,24 +54,29 @@ class AI_Client {
 			return;
 		}
 
-		// Wire up the WordPress HTTP client with the PHP AI Client SDK.
-		WP_AI_Client_Discovery_Strategy::init();
+		// On WordPress < 7.0, wire up the PHP AI Client SDK infrastructure.
+		// On 7.0+, core handles this natively, and loading these classes would
+		// cause PSR namespace conflicts with core's scoped dependencies.
+		if ( ! wp_has_ai_client() ) {
+			// Wire up the WordPress HTTP client with the PHP AI Client SDK.
+			WP_AI_Client_Discovery_Strategy::init();
 
-		// Wire up the WordPress event dispatcher with the PHP AI Client SDK.
-		AiClient::setEventDispatcher( new WordPress_Event_Dispatcher() );
+			// Wire up the WordPress event dispatcher with the PHP AI Client SDK.
+			AiClient::setEventDispatcher( new WordPress_Event_Dispatcher() );
 
-		// Wire up the WordPress cache with the PHP AI Client SDK.
-		AiClient::setCache( new WordPress_Cache() );
+			// Wire up the WordPress cache with the PHP AI Client SDK.
+			AiClient::setCache( new WordPress_Cache() );
 
-		// Initialize capabilities.
+			// Initialize the API credentials manager and settings screen.
+			( new API_Credentials_Manager() )->initialize();
+		}
+
+		// Initialize capabilities (idempotent with core).
 		add_filter( 'user_has_cap', array( Capabilities_Manager::class, 'grant_prompt_ai_to_administrators' ) );
 		add_filter( 'user_has_cap', array( Capabilities_Manager::class, 'grant_list_ai_providers_models_to_administrators' ) );
 
 		// Register client-side API script.
 		self::register_client_side_api_script();
-
-		// Initialize the API credentials manager and settings screen.
-		( new API_Credentials_Manager() )->initialize();
 
 		// Register REST API routes.
 		add_action(

--- a/includes/HTTP/WP_AI_Client_Discovery_Strategy.php
+++ b/includes/HTTP/WP_AI_Client_Discovery_Strategy.php
@@ -8,84 +8,26 @@
 
 namespace WordPress\AI_Client\HTTP;
 
-use Http\Discovery\Psr18ClientDiscovery;
-use Http\Discovery\Strategy\DiscoveryStrategy;
 use Nyholm\Psr7\Factory\Psr17Factory;
 use Psr\Http\Client\ClientInterface;
+use WordPress\AiClient\Providers\Http\Abstracts\AbstractClientDiscoveryStrategy;
 
 /**
  * Discovery strategy for WordPress HTTP client.
  *
  * @since 0.1.0
  */
-class WP_AI_Client_Discovery_Strategy implements DiscoveryStrategy {
+class WP_AI_Client_Discovery_Strategy extends AbstractClientDiscoveryStrategy {
 
 	/**
-	 * Initialize and register the discovery strategy.
+	 * Creates an instance of the WordPress HTTP client.
 	 *
 	 * @since 0.1.0
-	 * @return void
-	 */
-	public static function init() {
-		// Check if discovery is available.
-		if ( ! class_exists( '\Http\Discovery\Psr18ClientDiscovery' ) ) {
-			return;
-		}
-
-		// Register our discovery strategy.
-		Psr18ClientDiscovery::prependStrategy( self::class );
-	}
-
-	/**
-	 * Get candidates for discovery.
 	 *
-	 * @param string $type The type of discovery.
-	 *
-	 * @return array<array<string, mixed>>
+	 * @param Psr17Factory $psr17_factory The PSR-17 factory for creating HTTP messages.
+	 * @return ClientInterface The WordPress HTTP client instance.
 	 */
-	public static function getCandidates( $type ) {
-		// PSR-18 HTTP Client.
-		if ( ClientInterface::class === $type ) {
-			return array(
-				array(
-					'class' => static function () {
-						return self::createWordPressClient();
-					},
-				),
-			);
-		}
-
-		// PSR-17 factories - Nyholm's Psr17Factory implements all of them.
-		$psr17_factories = array(
-			'Psr\Http\Message\RequestFactoryInterface',
-			'Psr\Http\Message\ResponseFactoryInterface',
-			'Psr\Http\Message\ServerRequestFactoryInterface',
-			'Psr\Http\Message\StreamFactoryInterface',
-			'Psr\Http\Message\UploadedFileFactoryInterface',
-			'Psr\Http\Message\UriFactoryInterface',
-		);
-
-		if ( in_array( $type, $psr17_factories, true ) ) {
-			return array(
-				array(
-					'class' => Psr17Factory::class,
-				),
-			);
-		}
-
-		return array();
-	}
-
-	/**
-	 * Create an instance of the WordPress HTTP client.
-	 *
-	 * @return WordPress_HTTP_Client
-	 */
-	private static function createWordPressClient() {
-		$psr17_factory = new Psr17Factory();
-		return new WordPress_HTTP_Client(
-			$psr17_factory, // Response factory.
-			$psr17_factory  // Stream factory.
-		);
+	protected static function createClient( Psr17Factory $psr17_factory ): ClientInterface {
+		return new WordPress_HTTP_Client( $psr17_factory, $psr17_factory );
 	}
 }

--- a/includes/REST_API/AI_Prompt_REST_Controller.php
+++ b/includes/REST_API/AI_Prompt_REST_Controller.php
@@ -14,7 +14,7 @@ use WP_REST_Request;
 use WP_REST_Response;
 use WP_REST_Server;
 use WordPress\AI_Client\AI_Client;
-use WordPress\AI_Client\Builders\Prompt_Builder;
+use WordPress\AI_Client\Builders\Prompt_Builder_With_WP_Error;
 use WordPress\AI_Client\Capabilities\Capabilities_Manager;
 use WordPress\AiClient\AiClient;
 use WordPress\AiClient\Messages\DTO\Message;
@@ -124,6 +124,10 @@ class AI_Prompt_REST_Controller {
 			}
 
 			$result = $builder->generate_result( $capability );
+
+			if ( is_wp_error( $result ) ) {
+				return $result;
+			}
 
 			return new WP_REST_Response( $result, 200 );
 		} catch ( Exception $e ) {
@@ -267,13 +271,15 @@ class AI_Prompt_REST_Controller {
 	}
 
 	/**
-	 * Helper to create builder from params.
+	 * Creates a prompt builder from request parameters.
+	 *
+	 * @since 0.2.0
 	 *
 	 * @param array<string, mixed> $params The parameters.
 	 * @phpstan-param GenerationRequestParams $params
-	 * @return Prompt_Builder The builder instance.
+	 * @return Prompt_Builder_With_WP_Error The builder instance.
 	 */
-	private function create_builder_from_params( array $params ): Prompt_Builder {
+	private function create_builder_from_params( array $params ): Prompt_Builder_With_WP_Error {
 		// Messages are required by schema.
 		$messages_data = $params['messages'];
 
@@ -282,7 +288,7 @@ class AI_Prompt_REST_Controller {
 			$messages_data
 		);
 
-		$builder = AI_Client::prompt( array_values( $messages ) );
+		$builder = wp_ai_client_prompt( array_values( $messages ) );
 
 		if ( ! empty( $params['modelConfig'] ) && is_array( $params['modelConfig'] ) ) {
 			$model_config_data = $params['modelConfig'];

--- a/includes/REST_API/AI_Prompt_REST_Controller.php
+++ b/includes/REST_API/AI_Prompt_REST_Controller.php
@@ -279,7 +279,7 @@ class AI_Prompt_REST_Controller {
 	 * @phpstan-param GenerationRequestParams $params
 	 * @return Prompt_Builder_With_WP_Error The builder instance.
 	 */
-	private function create_builder_from_params( array $params ): Prompt_Builder_With_WP_Error {
+	private function create_builder_from_params( array $params ) {
 		// Messages are required by schema.
 		$messages_data = $params['messages'];
 

--- a/plugin.php
+++ b/plugin.php
@@ -21,6 +21,26 @@ if ( ! defined( 'ABSPATH' ) ) {
 
 // When WordPress 7.0+ is present, the AI client is provided natively by core.
 if ( function_exists( 'wp_get_wp_version' ) && version_compare( wp_get_wp_version(), '7.0-alpha', '>=' ) ) {
+	add_action(
+		'admin_notices',
+		static function () {
+			if ( ! current_user_can( 'deactivate_plugins' ) ) {
+				return;
+			}
+
+			$deactivate_url = wp_nonce_url(
+				admin_url( 'plugins.php?action=deactivate&plugin=' . rawurlencode( plugin_basename( __FILE__ ) ) ),
+				'deactivate-plugin_' . plugin_basename( __FILE__ )
+			);
+
+			printf(
+				'<div class="notice notice-info"><p>%s</p><p><a href="%s" class="button">%s</a></p></div>',
+				esc_html__( 'The AI Client plugin is no longer needed. WordPress now includes the AI client natively.', 'wp-ai-client' ),
+				esc_url( $deactivate_url ),
+				esc_html__( 'Deactivate AI Client plugin', 'wp-ai-client' )
+			);
+		}
+	);
 	return;
 }
 

--- a/plugin.php
+++ b/plugin.php
@@ -19,6 +19,31 @@ if ( ! defined( 'ABSPATH' ) ) {
 	exit; // Exit if accessed directly.
 }
 
-require_once __DIR__ . '/vendor/autoload.php';
+require_once __DIR__ . '/functions.php';
+
+if ( ! wp_has_ai_client() ) {
+	// On < 7.0, load the full Composer autoloader (PHP AI Client SDK, PSR
+	// packages, and this plugin's own classes).
+	require_once __DIR__ . '/vendor/autoload.php';
+} else {
+	// On 7.0+, only autoload this plugin's own classes. Core provides the
+	// AI client SDK natively with scoped PSR dependencies; loading this
+	// plugin's vendor autoloader would cause fatal declaration-compatibility
+	// errors between unscoped Psr\* types and core's scoped versions.
+	spl_autoload_register(
+		static function ( $class ) {
+			$prefix = 'WordPress\\AI_Client\\';
+			$len    = strlen( $prefix );
+			if ( strncmp( $class, $prefix, $len ) !== 0 ) {
+				return;
+			}
+			$relative_class = substr( $class, $len );
+			$file           = __DIR__ . '/includes/' . str_replace( '\\', '/', $relative_class ) . '.php';
+			if ( file_exists( $file ) ) {
+				require $file;
+			}
+		}
+	);
+}
 
 add_action( 'init', array( WordPress\AI_Client\AI_Client::class, 'init' ) );

--- a/plugin.php
+++ b/plugin.php
@@ -46,21 +46,4 @@ if ( function_exists( 'wp_get_wp_version' ) && version_compare( wp_get_wp_versio
 
 require_once __DIR__ . '/vendor/autoload.php';
 
-if ( ! function_exists( 'wp_ai_client_prompt' ) ) {
-	/**
-	 * Creates a new AI prompt builder for fluent API usage, returning WP_Error on errors.
-	 *
-	 * This is the standard entry point for the WordPress AI Client API. It mirrors
-	 * core's wp_ai_client_prompt() available in WordPress 7.0+.
-	 *
-	 * @since n.e.x.t
-	 *
-	 * @param string|null $prompt Optional initial prompt content.
-	 * @return WordPress\AI_Client\Builders\Prompt_Builder_With_WP_Error The prompt builder instance.
-	 */
-	function wp_ai_client_prompt( $prompt = null ) {
-		return new WordPress\AI_Client\Builders\Prompt_Builder_With_WP_Error( WordPress\AiClient\AiClient::defaultRegistry(), $prompt );
-	}
-}
-
 add_action( 'init', array( WordPress\AI_Client\AI_Client::class, 'init' ) );

--- a/plugin.php
+++ b/plugin.php
@@ -19,31 +19,6 @@ if ( ! defined( 'ABSPATH' ) ) {
 	exit; // Exit if accessed directly.
 }
 
-require_once __DIR__ . '/functions.php';
-
-if ( ! wp_has_ai_client() ) {
-	// On < 7.0, load the full Composer autoloader (PHP AI Client SDK, PSR
-	// packages, and this plugin's own classes).
-	require_once __DIR__ . '/vendor/autoload.php';
-} else {
-	// On 7.0+, only autoload this plugin's own classes. Core provides the
-	// AI client SDK natively with scoped PSR dependencies; loading this
-	// plugin's vendor autoloader would cause fatal declaration-compatibility
-	// errors between unscoped Psr\* types and core's scoped versions.
-	spl_autoload_register(
-		static function ( $class ) {
-			$prefix = 'WordPress\\AI_Client\\';
-			$len    = strlen( $prefix );
-			if ( strncmp( $class, $prefix, $len ) !== 0 ) {
-				return;
-			}
-			$relative_class = substr( $class, $len );
-			$file           = __DIR__ . '/includes/' . str_replace( '\\', '/', $relative_class ) . '.php';
-			if ( file_exists( $file ) ) {
-				require $file;
-			}
-		}
-	);
-}
+require_once __DIR__ . '/autoload.php';
 
 add_action( 'init', array( WordPress\AI_Client\AI_Client::class, 'init' ) );

--- a/plugin.php
+++ b/plugin.php
@@ -19,6 +19,28 @@ if ( ! defined( 'ABSPATH' ) ) {
 	exit; // Exit if accessed directly.
 }
 
+// When WordPress 7.0+ is present, the AI client is provided natively by core.
+if ( function_exists( 'wp_get_wp_version' ) && version_compare( wp_get_wp_version(), '7.0-alpha', '>=' ) ) {
+	return;
+}
+
 require_once __DIR__ . '/vendor/autoload.php';
+
+if ( ! function_exists( 'wp_ai_client_prompt' ) ) {
+	/**
+	 * Creates a new AI prompt builder for fluent API usage, returning WP_Error on errors.
+	 *
+	 * This is the standard entry point for the WordPress AI Client API. It mirrors
+	 * core's wp_ai_client_prompt() available in WordPress 7.0+.
+	 *
+	 * @since n.e.x.t
+	 *
+	 * @param string|null $prompt Optional initial prompt content.
+	 * @return WordPress\AI_Client\Builders\Prompt_Builder_With_WP_Error The prompt builder instance.
+	 */
+	function wp_ai_client_prompt( $prompt = null ) {
+		return new WordPress\AI_Client\Builders\Prompt_Builder_With_WP_Error( WordPress\AiClient\AiClient::defaultRegistry(), $prompt );
+	}
+}
 
 add_action( 'init', array( WordPress\AI_Client\AI_Client::class, 'init' ) );

--- a/plugin.php
+++ b/plugin.php
@@ -19,8 +19,10 @@ if ( ! defined( 'ABSPATH' ) ) {
 	exit; // Exit if accessed directly.
 }
 
+require_once __DIR__ . '/vendor/autoload.php';
+
 // When WordPress 7.0+ is present, the AI client is provided natively by core.
-if ( function_exists( 'wp_get_wp_version' ) && version_compare( wp_get_wp_version(), '7.0-alpha', '>=' ) ) {
+if ( wp_has_ai_client() ) {
 	add_action(
 		'admin_notices',
 		static function () {
@@ -43,7 +45,5 @@ if ( function_exists( 'wp_get_wp_version' ) && version_compare( wp_get_wp_versio
 	);
 	return;
 }
-
-require_once __DIR__ . '/vendor/autoload.php';
 
 add_action( 'init', array( WordPress\AI_Client\AI_Client::class, 'init' ) );

--- a/plugin.php
+++ b/plugin.php
@@ -21,29 +21,4 @@ if ( ! defined( 'ABSPATH' ) ) {
 
 require_once __DIR__ . '/vendor/autoload.php';
 
-// When WordPress 7.0+ is present, the AI client is provided natively by core.
-if ( wp_has_ai_client() ) {
-	add_action(
-		'admin_notices',
-		static function () {
-			if ( ! current_user_can( 'deactivate_plugins' ) ) {
-				return;
-			}
-
-			$deactivate_url = wp_nonce_url(
-				admin_url( 'plugins.php?action=deactivate&plugin=' . rawurlencode( plugin_basename( __FILE__ ) ) ),
-				'deactivate-plugin_' . plugin_basename( __FILE__ )
-			);
-
-			printf(
-				'<div class="notice notice-info"><p>%s</p><p><a href="%s" class="button">%s</a></p></div>',
-				esc_html__( 'The AI Client plugin is no longer needed. WordPress now includes the AI client natively.', 'wp-ai-client' ),
-				esc_url( $deactivate_url ),
-				esc_html__( 'Deactivate AI Client plugin', 'wp-ai-client' )
-			);
-		}
-	);
-	return;
-}
-
 add_action( 'init', array( WordPress\AI_Client\AI_Client::class, 'init' ) );

--- a/tests/phpunit/bootstrap.php
+++ b/tests/phpunit/bootstrap.php
@@ -7,8 +7,6 @@
 
 define( 'WP_AI_CLIENT_PROJECT_DIR', dirname( dirname( __DIR__ ) ) );
 
-require_once WP_AI_CLIENT_PROJECT_DIR . '/vendor/autoload.php';
-
 // Detect where to load the WordPress tests environment from.
 if ( false !== getenv( 'WP_TESTS_DIR' ) ) {
 	$wp_ai_client_test_root = getenv( 'WP_TESTS_DIR' );
@@ -18,6 +16,26 @@ if ( false !== getenv( 'WP_TESTS_DIR' ) ) {
 	$wp_ai_client_test_root = getenv( 'WP_PHPUNIT__DIR' );
 } else { // Fallback.
 	$wp_ai_client_test_root = '/tmp/wordpress-tests-lib';
+}
+
+/*
+ * Only load the vendor autoloader when running tests against WP < 7.0.
+ *
+ * At runtime, plugin.php always loads the autoloader — that's safe because
+ * Composer autoloading is lazy and AI_Client::init() guards the code paths
+ * that would trigger PSR scoping conflicts with core's scoped dependencies.
+ *
+ * The test environment is different: test code directly references SDK classes
+ * (e.g. via reflection, assertions, mock providers), which forces them to load
+ * eagerly. On WP 7.0+, this would cause fatal declaration-compatibility errors
+ * between the plugin's unscoped Psr\* types and core's scoped versions.
+ */
+$wp_ai_client_version_file = dirname( dirname( $wp_ai_client_test_root ) ) . '/wp-includes/version.php';
+if ( file_exists( $wp_ai_client_version_file ) ) {
+	require $wp_ai_client_version_file;
+}
+if ( ! isset( $wp_version ) || version_compare( $wp_version, '7.0-alpha', '<' ) ) {
+	require_once WP_AI_CLIENT_PROJECT_DIR . '/vendor/autoload.php';
 }
 
 // Force empty test plugin containing the library to be active.

--- a/tests/phpunit/bootstrap.php
+++ b/tests/phpunit/bootstrap.php
@@ -19,24 +19,12 @@ if ( false !== getenv( 'WP_TESTS_DIR' ) ) {
 }
 
 /*
- * Only load the vendor autoloader when running tests against WP < 7.0.
- *
- * At runtime, plugin.php always loads the autoloader — that's safe because
- * Composer autoloading is lazy and AI_Client::init() guards the code paths
- * that would trigger PSR scoping conflicts with core's scoped dependencies.
- *
- * The test environment is different: test code directly references SDK classes
- * (e.g. via reflection, assertions, mock providers), which forces them to load
- * eagerly. On WP 7.0+, this would cause fatal declaration-compatibility errors
- * between the plugin's unscoped Psr\* types and core's scoped versions.
+ * Do not load the vendor autoloader here. plugin.php handles it conditionally:
+ * on < 7.0 it loads the full Composer autoloader, on 7.0+ it registers a
+ * minimal PSR-4 autoloader for only this plugin's own classes (to avoid PSR
+ * scoping conflicts with core's scoped dependencies). No plugin classes are
+ * needed before the WordPress test bootstrap activates the plugin below.
  */
-$wp_ai_client_version_file = dirname( dirname( $wp_ai_client_test_root ) ) . '/wp-includes/version.php';
-if ( file_exists( $wp_ai_client_version_file ) ) {
-	require $wp_ai_client_version_file;
-}
-if ( ! isset( $wp_version ) || version_compare( $wp_version, '7.0-alpha', '<' ) ) {
-	require_once WP_AI_CLIENT_PROJECT_DIR . '/vendor/autoload.php';
-}
 
 // Force empty test plugin containing the library to be active.
 $GLOBALS['wp_tests_options'] = array( // phpcs:ignore WordPress.NamingConventions.PrefixAllGlobals.NonPrefixedVariableFound

--- a/tests/phpunit/tests/AI_Client_Tests.php
+++ b/tests/phpunit/tests/AI_Client_Tests.php
@@ -34,7 +34,14 @@ class AI_Client_Tests extends Test_Case {
 		// First init call.
 		AI_Client::init();
 		$this->assertTrue( $initialized_property->getValue() );
-		$this->assertHasAction( 'admin_menu' );
+
+		// On < 7.0, API_Credentials_Manager adds an admin_menu action.
+		// On 7.0+, SDK infrastructure is skipped (core handles it).
+		if ( wp_has_ai_client() ) {
+			$this->assertNotHasAction( 'admin_menu' );
+		} else {
+			$this->assertHasAction( 'admin_menu' );
+		}
 
 		// Now we remove the added action again to verify that the second init call does not add it again.
 		remove_all_actions( 'admin_menu' );

--- a/tests/phpunit/tests/REST_API/AI_Prompt_REST_Controller_Tests.php
+++ b/tests/phpunit/tests/REST_API/AI_Prompt_REST_Controller_Tests.php
@@ -80,7 +80,7 @@ class AI_Prompt_REST_Controller_Tests extends Test_Case {
 		$response = $controller->process_generate_request( $request );
 
 		if ( is_wp_error( $response ) ) {
-			$this->assertEquals( 'ai_generate_error', $response->get_error_code() );
+			$this->assertEquals( 'prompt_builder_error', $response->get_error_code() );
 		} else {
 			$this->assertEquals( 200, $response->get_status() );
 		}
@@ -150,7 +150,7 @@ class AI_Prompt_REST_Controller_Tests extends Test_Case {
 
 		$builder = $method->invoke( $controller, $params );
 
-		$this->assertInstanceOf( 'WordPress\AI_Client\Builders\Prompt_Builder', $builder );
+		$this->assertInstanceOf( 'WordPress\AI_Client\Builders\Prompt_Builder_With_WP_Error', $builder );
 
 		// Verify internal state.
 		$inner_builder = $this->get_private_property( $builder, 'builder' );
@@ -196,7 +196,7 @@ class AI_Prompt_REST_Controller_Tests extends Test_Case {
 
 		$builder = $method->invoke( $controller, $params );
 
-		$this->assertInstanceOf( 'WordPress\AI_Client\Builders\Prompt_Builder', $builder );
+		$this->assertInstanceOf( 'WordPress\AI_Client\Builders\Prompt_Builder_With_WP_Error', $builder );
 
 		// Verify internal state.
 		$inner_builder   = $this->get_private_property( $builder, 'builder' );
@@ -239,7 +239,7 @@ class AI_Prompt_REST_Controller_Tests extends Test_Case {
 
 		$builder = $method->invoke( $controller, $params );
 
-		$this->assertInstanceOf( 'WordPress\AI_Client\Builders\Prompt_Builder', $builder );
+		$this->assertInstanceOf( 'WordPress\AI_Client\Builders\Prompt_Builder_With_WP_Error', $builder );
 
 		// Verify internal state.
 		$inner_builder = $this->get_private_property( $builder, 'builder' );
@@ -258,8 +258,15 @@ class AI_Prompt_REST_Controller_Tests extends Test_Case {
 	 */
 	private function get_private_property( $obj, $property ) {
 		$reflection = new ReflectionClass( $obj );
-		$prop       = $reflection->getProperty( $property );
-		$prop->setAccessible( true );
-		return $prop->getValue( $obj );
+		while ( $reflection ) {
+			if ( $reflection->hasProperty( $property ) ) {
+				$prop = $reflection->getProperty( $property );
+				$prop->setAccessible( true );
+				return $prop->getValue( $obj );
+			}
+			$reflection = $reflection->getParentClass();
+		}
+		// phpcs:ignore WordPress.Security.EscapeOutput.ExceptionNotEscaped -- Test-only helper.
+		throw new \ReflectionException( "Property {$property} does not exist on " . get_class( $obj ) . ' or its parents.' );
 	}
 }


### PR DESCRIPTION
As the AI Client makes its way to WordPress 7.0 we need to prepare this package for the transition. It will be archived after the 7.0 release. This is how we're preparing this for the change:

  - Add wp_ai_client_prompt() global function as the standard entry point, matching core's WordPress 7.0 API
  - Add version gate so the plugin is a no-op on WordPress 7.0+ (core provides the AI client natively)
  - Update wordpress/php-ai-client to ^1.1 and refactor WP_AI_Client_Discovery_Strategy to extend the new AbstractClientDiscoveryStrategy
  - Remove direct nyholm/psr7 dependency (now provided transitively by php-ai-client)
  - Update README examples to use wp_ai_client_prompt() and add deprecation notice
  - Add UPGRADE.md documenting the transition to core
  - When used as a standalone plugin in 7.0+, a notice will be displayed to the admin that deactivation is safe and encouraged