### PR TITLE
Require providing allowed abilities in `Ability_Function_Resolver`, and make it non-static (for the most part)

### DIFF
--- a/includes/Builders/Helpers/Ability_Function_Resolver.php
+++ b/includes/Builders/Helpers/Ability_Function_Resolver.php
@@ -177,11 +177,12 @@ class Ability_Function_Resolver {
 	 * Transforms "wpab__tec__create_event" to "tec/create_event".
 	 *
 	 * @since 0.2.0
+	 * @since n.e.x.t Made public, for parity with Core implementation.
 	 *
 	 * @param string $function_name The function name to convert.
 	 * @return string The ability name.
 	 */
-	private static function function_name_to_ability_name( string $function_name ): string {
+	public static function function_name_to_ability_name( string $function_name ): string {
 		// Remove the ability prefix.
 		$without_prefix = substr( $function_name, strlen( self::ABILITY_PREFIX ) );
 

--- a/includes/Builders/Helpers/Ability_Function_Resolver.php
+++ b/includes/Builders/Helpers/Ability_Function_Resolver.php
@@ -18,7 +18,12 @@ use WP_Ability;
 /**
  * Resolves and executes WordPress Abilities API function calls from AI models.
  *
+ * This class must be instantiated with the specific abilities that the AI model
+ * is allowed to execute, ensuring that only explicitly specified abilities can
+ * be called. This prevents the model from executing arbitrary abilities.
+ *
  * @since 0.2.0
+ * @since n.e.x.t Converted from static-only to instance-based, with allowed abilities enforcement.
  */
 class Ability_Function_Resolver {
 
@@ -30,14 +35,44 @@ class Ability_Function_Resolver {
 	private const ABILITY_PREFIX = 'wpab__';
 
 	/**
+	 * Map of allowed ability names for this instance.
+	 *
+	 * Keys are ability name strings, values are `true` for O(1) lookup.
+	 *
+	 * @since n.e.x.t
+	 * @var array<string, true>
+	 */
+	private array $allowed_abilities;
+
+	/**
+	 * Constructor.
+	 *
+	 * @since n.e.x.t
+	 *
+	 * @param WP_Ability|string ...$abilities The abilities that this resolver is allowed to execute.
+	 */
+	public function __construct( ...$abilities ) {
+		$this->allowed_abilities = array();
+
+		foreach ( $abilities as $ability ) {
+			if ( $ability instanceof WP_Ability ) {
+				$this->allowed_abilities[ $ability->get_name() ] = true;
+			} elseif ( is_string( $ability ) ) {
+				$this->allowed_abilities[ $ability ] = true;
+			}
+		}
+	}
+
+	/**
 	 * Checks if a function call is an ability call.
 	 *
 	 * @since 0.2.0
+	 * @since n.e.x.t No longer static; use an instance of this class.
 	 *
 	 * @param FunctionCall $call The function call to check.
 	 * @return bool True if the function call is an ability call, false otherwise.
 	 */
-	public static function is_ability_call( FunctionCall $call ): bool {
+	public function is_ability_call( FunctionCall $call ): bool {
 		$name = $call->getName();
 		if ( null === $name ) {
 			return false;
@@ -49,17 +84,21 @@ class Ability_Function_Resolver {
 	/**
 	 * Executes a WordPress ability from a function call.
 	 *
+	 * Only abilities that were specified in the constructor are allowed to be
+	 * executed. If the ability is not in the allowed list, an error response
+	 * with code `ability_not_allowed` is returned.
+	 *
 	 * @since 0.2.0
+	 * @since n.e.x.t No longer static; use an instance of this class.
 	 *
 	 * @param FunctionCall $call The function call to execute.
 	 * @return FunctionResponse The response from executing the ability.
 	 */
-	public static function execute_ability( FunctionCall $call ): FunctionResponse {
+	public function execute_ability( FunctionCall $call ): FunctionResponse {
 		$function_name = $call->getName() ?? 'unknown';
 		$function_id   = $call->getId() ?? 'unknown';
 
-		// Validate that this is an ability call.
-		if ( ! self::is_ability_call( $call ) ) {
+		if ( ! $this->is_ability_call( $call ) ) {
 			return new FunctionResponse(
 				$function_id,
 				$function_name,
@@ -70,10 +109,19 @@ class Ability_Function_Resolver {
 			);
 		}
 
-		// Convert function name to ability name.
 		$ability_name = self::function_name_to_ability_name( $function_name );
 
-		// Get the ability.
+		if ( ! isset( $this->allowed_abilities[ $ability_name ] ) ) {
+			return new FunctionResponse(
+				$function_id,
+				$function_name,
+				array(
+					'error' => sprintf( 'Ability "%s" was not specified in the allowed abilities list.', $ability_name ),
+					'code'  => 'ability_not_allowed',
+				)
+			);
+		}
+
 		$ability = wp_get_ability( $ability_name );
 
 		if ( ! $ability instanceof WP_Ability ) {
@@ -87,11 +135,9 @@ class Ability_Function_Resolver {
 			);
 		}
 
-		// Execute the ability.
 		$args   = $call->getArgs();
 		$result = $ability->execute( $args );
 
-		// Handle WP_Error responses.
 		if ( is_wp_error( $result ) ) {
 			return new FunctionResponse(
 				$function_id,
@@ -104,7 +150,6 @@ class Ability_Function_Resolver {
 			);
 		}
 
-		// Return successful response.
 		return new FunctionResponse(
 			$function_id,
 			$function_name,
@@ -116,15 +161,16 @@ class Ability_Function_Resolver {
 	 * Checks if a message contains any ability function calls.
 	 *
 	 * @since 0.2.0
+	 * @since n.e.x.t No longer static; use an instance of this class.
 	 *
 	 * @param Message $message The message to check.
 	 * @return bool True if the message contains ability calls, false otherwise.
 	 */
-	public static function has_ability_calls( Message $message ): bool {
+	public function has_ability_calls( Message $message ): bool {
 		foreach ( $message->getParts() as $part ) {
 			if ( $part->getType()->isFunctionCall() ) {
 				$function_call = $part->getFunctionCall();
-				if ( $function_call instanceof FunctionCall && self::is_ability_call( $function_call ) ) {
+				if ( $function_call instanceof FunctionCall && $this->is_ability_call( $function_call ) ) {
 					return true;
 				}
 			}
@@ -137,18 +183,19 @@ class Ability_Function_Resolver {
 	 * Executes all ability function calls in a message.
 	 *
 	 * @since 0.2.0
+	 * @since n.e.x.t No longer static; use an instance of this class.
 	 *
 	 * @param Message $message The message containing function calls.
 	 * @return Message A new message with function responses.
 	 */
-	public static function execute_abilities( Message $message ): Message {
+	public function execute_abilities( Message $message ): Message {
 		$response_parts = array();
 
 		foreach ( $message->getParts() as $part ) {
 			if ( $part->getType()->isFunctionCall() ) {
 				$function_call = $part->getFunctionCall();
 				if ( $function_call instanceof FunctionCall ) {
-					$function_response = self::execute_ability( $function_call );
+					$function_response = $this->execute_ability( $function_call );
 					$response_parts[]  = new MessagePart( $function_response );
 				}
 			}
@@ -183,10 +230,8 @@ class Ability_Function_Resolver {
 	 * @return string The ability name.
 	 */
 	public static function function_name_to_ability_name( string $function_name ): string {
-		// Remove the ability prefix.
 		$without_prefix = substr( $function_name, strlen( self::ABILITY_PREFIX ) );
 
-		// Convert double underscores to forward slashes.
 		return str_replace( '__', '/', $without_prefix );
 	}
 }

--- a/tests/phpunit/tests/Abilities/Ability_Function_Resolver_Tests.php
+++ b/tests/phpunit/tests/Abilities/Ability_Function_Resolver_Tests.php
@@ -28,63 +28,69 @@ use WordPress\AiClient\Tools\DTO\FunctionResponse;
 class Ability_Function_Resolver_Test extends Test_Case {
 
 	/**
-	 * Tests is_ability_call returns true for valid ability calls.
+	 * Tests is_ability_call returns true for valid ability calls via instance.
 	 *
 	 * @return void
 	 */
 	public function test_is_ability_call_returns_true_for_valid_ability(): void {
-		$call = new FunctionCall( 'func_123', 'wpab__tec__create_event', array( 'title' => 'Test Event' ) );
-		$this->assertTrue( Ability_Function_Resolver::is_ability_call( $call ) );
+		$resolver = new Ability_Function_Resolver( 'tec/create_event' );
+		$call     = new FunctionCall( 'func_123', 'wpab__tec__create_event', array( 'title' => 'Test Event' ) );
+		$this->assertTrue( $resolver->is_ability_call( $call ) );
 	}
 
 	/**
-	 * Tests is_ability_call returns true for nested namespace abilities.
+	 * Tests is_ability_call returns true for nested namespace abilities via instance.
 	 *
 	 * @return void
 	 */
 	public function test_is_ability_call_returns_true_for_nested_namespace(): void {
-		$call = new FunctionCall( 'func_456', 'wpab__tec__v1__create_event', array() );
-		$this->assertTrue( Ability_Function_Resolver::is_ability_call( $call ) );
+		$resolver = new Ability_Function_Resolver( 'tec/v1/create_event' );
+		$call     = new FunctionCall( 'func_456', 'wpab__tec__v1__create_event', array() );
+		$this->assertTrue( $resolver->is_ability_call( $call ) );
 	}
 
 	/**
-	 * Tests is_ability_call returns false for non-ability calls.
+	 * Tests is_ability_call returns false for non-ability calls via instance.
 	 *
 	 * @return void
 	 */
 	public function test_is_ability_call_returns_false_for_non_ability(): void {
-		$call = new FunctionCall( 'func_789', 'regular_function', array() );
-		$this->assertFalse( Ability_Function_Resolver::is_ability_call( $call ) );
+		$resolver = new Ability_Function_Resolver();
+		$call     = new FunctionCall( 'func_789', 'regular_function', array() );
+		$this->assertFalse( $resolver->is_ability_call( $call ) );
 	}
 
 	/**
-	 * Tests is_ability_call returns false when function name is null.
+	 * Tests is_ability_call returns false when function name is null via instance.
 	 *
 	 * @return void
 	 */
 	public function test_is_ability_call_returns_false_when_name_is_null(): void {
-		$call = new FunctionCall( 'func_999', null, array() );
-		$this->assertFalse( Ability_Function_Resolver::is_ability_call( $call ) );
+		$resolver = new Ability_Function_Resolver();
+		$call     = new FunctionCall( 'func_999', null, array() );
+		$this->assertFalse( $resolver->is_ability_call( $call ) );
 	}
 
 	/**
-	 * Tests is_ability_call returns false for partial prefix match.
+	 * Tests is_ability_call returns false for partial prefix match via instance.
 	 *
 	 * @return void
 	 */
 	public function test_is_ability_call_returns_false_for_partial_prefix(): void {
-		$call = new FunctionCall( 'func_111', 'wpab_single_underscore', array() );
-		$this->assertFalse( Ability_Function_Resolver::is_ability_call( $call ) );
+		$resolver = new Ability_Function_Resolver();
+		$call     = new FunctionCall( 'func_111', 'wpab_single_underscore', array() );
+		$this->assertFalse( $resolver->is_ability_call( $call ) );
 	}
 
 	/**
-	 * Tests execute_ability returns error for non-ability call.
+	 * Tests execute_ability returns error for non-ability call via instance.
 	 *
 	 * @return void
 	 */
 	public function test_execute_ability_returns_error_for_non_ability_call(): void {
+		$resolver = new Ability_Function_Resolver();
 		$call     = new FunctionCall( 'func_123', 'regular_function', array() );
-		$response = Ability_Function_Resolver::execute_ability( $call );
+		$response = $resolver->execute_ability( $call );
 
 		$this->assertInstanceOf( FunctionResponse::class, $response );
 		$this->assertEquals( 'func_123', $response->getId() );
@@ -98,16 +104,16 @@ class Ability_Function_Resolver_Test extends Test_Case {
 	}
 
 	/**
-	 * Tests execute_ability returns error when ability not found.
+	 * Tests execute_ability returns error when ability not found via instance.
 	 *
 	 * @return void
 	 */
 	public function test_execute_ability_returns_error_when_ability_not_found(): void {
-		// WordPress 6.9 triggers an incorrect usage notice when ability is not found.
 		$this->setExpectedIncorrectUsage( 'WP_Abilities_Registry::get_registered' );
 
+		$resolver = new Ability_Function_Resolver( 'nonexistent/ability' );
 		$call     = new FunctionCall( 'func_456', 'wpab__nonexistent__ability', array() );
-		$response = Ability_Function_Resolver::execute_ability( $call );
+		$response = $resolver->execute_ability( $call );
 
 		$this->assertInstanceOf( FunctionResponse::class, $response );
 		$this->assertEquals( 'func_456', $response->getId() );
@@ -121,27 +127,28 @@ class Ability_Function_Resolver_Test extends Test_Case {
 	}
 
 	/**
-	 * Tests execute_ability handles missing function ID.
+	 * Tests execute_ability handles missing function ID via instance.
 	 *
 	 * @return void
 	 */
 	public function test_execute_ability_handles_missing_id(): void {
-		// WordPress 6.9 triggers an incorrect usage notice when ability is not found.
 		$this->setExpectedIncorrectUsage( 'WP_Abilities_Registry::get_registered' );
 
+		$resolver = new Ability_Function_Resolver( 'test/missing' );
 		$call     = new FunctionCall( null, 'wpab__test__missing', array() );
-		$response = Ability_Function_Resolver::execute_ability( $call );
+		$response = $resolver->execute_ability( $call );
 
 		$this->assertInstanceOf( FunctionResponse::class, $response );
 		$this->assertEquals( 'unknown', $response->getId() );
 	}
 
 	/**
-	 * Tests has_ability_calls returns true when message contains ability calls.
+	 * Tests has_ability_calls returns true when message contains ability calls via instance.
 	 *
 	 * @return void
 	 */
 	public function test_has_ability_calls_returns_true_when_present(): void {
+		$resolver      = new Ability_Function_Resolver( 'tec/create_event' );
 		$function_call = new FunctionCall( 'func_123', 'wpab__tec__create_event', array() );
 		$parts         = array(
 			new MessagePart( 'Some text' ),
@@ -149,15 +156,16 @@ class Ability_Function_Resolver_Test extends Test_Case {
 		);
 		$message       = new ModelMessage( $parts );
 
-		$this->assertTrue( Ability_Function_Resolver::has_ability_calls( $message ) );
+		$this->assertTrue( $resolver->has_ability_calls( $message ) );
 	}
 
 	/**
-	 * Tests has_ability_calls returns false when no ability calls present.
+	 * Tests has_ability_calls returns false when no ability calls present via instance.
 	 *
 	 * @return void
 	 */
 	public function test_has_ability_calls_returns_false_when_not_present(): void {
+		$resolver      = new Ability_Function_Resolver();
 		$function_call = new FunctionCall( 'func_456', 'regular_function', array() );
 		$parts         = array(
 			new MessagePart( 'Some text' ),
@@ -165,27 +173,29 @@ class Ability_Function_Resolver_Test extends Test_Case {
 		);
 		$message       = new ModelMessage( $parts );
 
-		$this->assertFalse( Ability_Function_Resolver::has_ability_calls( $message ) );
+		$this->assertFalse( $resolver->has_ability_calls( $message ) );
 	}
 
 	/**
-	 * Tests has_ability_calls returns false for text-only message.
+	 * Tests has_ability_calls returns false for text-only message via instance.
 	 *
 	 * @return void
 	 */
 	public function test_has_ability_calls_returns_false_for_text_only(): void {
-		$parts   = array( new MessagePart( 'Just text' ) );
-		$message = new UserMessage( $parts );
+		$resolver = new Ability_Function_Resolver();
+		$parts    = array( new MessagePart( 'Just text' ) );
+		$message  = new UserMessage( $parts );
 
-		$this->assertFalse( Ability_Function_Resolver::has_ability_calls( $message ) );
+		$this->assertFalse( $resolver->has_ability_calls( $message ) );
 	}
 
 	/**
-	 * Tests has_ability_calls returns true with mixed content.
+	 * Tests has_ability_calls returns true with mixed content via instance.
 	 *
 	 * @return void
 	 */
 	public function test_has_ability_calls_returns_true_with_mixed_content(): void {
+		$resolver     = new Ability_Function_Resolver( 'test/ability' );
 		$regular_call = new FunctionCall( 'func_1', 'regular_function', array() );
 		$ability_call = new FunctionCall( 'func_2', 'wpab__test__ability', array() );
 		$parts        = array(
@@ -195,46 +205,48 @@ class Ability_Function_Resolver_Test extends Test_Case {
 		);
 		$message      = new ModelMessage( $parts );
 
-		$this->assertTrue( Ability_Function_Resolver::has_ability_calls( $message ) );
+		$this->assertTrue( $resolver->has_ability_calls( $message ) );
 	}
 
 	/**
-	 * Tests has_ability_calls with empty message.
+	 * Tests has_ability_calls with empty message via instance.
 	 *
 	 * @return void
 	 */
 	public function test_has_ability_calls_with_empty_message(): void {
-		$message = new ModelMessage( array() );
-		$this->assertFalse( Ability_Function_Resolver::has_ability_calls( $message ) );
+		$resolver = new Ability_Function_Resolver();
+		$message  = new ModelMessage( array() );
+		$this->assertFalse( $resolver->has_ability_calls( $message ) );
 	}
 
 	/**
-	 * Tests execute_abilities with empty message.
+	 * Tests execute_abilities with empty message via instance.
 	 *
 	 * @return void
 	 */
 	public function test_execute_abilities_with_empty_message(): void {
-		$message = new ModelMessage( array() );
-		$result  = Ability_Function_Resolver::execute_abilities( $message );
+		$resolver = new Ability_Function_Resolver();
+		$message  = new ModelMessage( array() );
+		$result   = $resolver->execute_abilities( $message );
 
 		$this->assertInstanceOf( Message::class, $result );
 		$this->assertCount( 0, $result->getParts() );
 	}
 
 	/**
-	 * Tests execute_abilities handles errors gracefully when ability not found.
+	 * Tests execute_abilities handles errors gracefully when ability not found via instance.
 	 *
 	 * @return void
 	 */
 	public function test_execute_abilities_handles_errors_gracefully(): void {
-		// WordPress 6.9 triggers an incorrect usage notice when ability is not found.
 		$this->setExpectedIncorrectUsage( 'WP_Abilities_Registry::get_registered' );
 
-		$call    = new FunctionCall( 'func_1', 'wpab__nonexistent__ability', array() );
-		$parts   = array( new MessagePart( $call ) );
-		$message = new ModelMessage( $parts );
+		$resolver = new Ability_Function_Resolver( 'nonexistent/ability' );
+		$call     = new FunctionCall( 'func_1', 'wpab__nonexistent__ability', array() );
+		$parts    = array( new MessagePart( $call ) );
+		$message  = new ModelMessage( $parts );
 
-		$result = Ability_Function_Resolver::execute_abilities( $message );
+		$result = $resolver->execute_abilities( $message );
 
 		$this->assertInstanceOf( Message::class, $result );
 		$this->assertInstanceOf( UserMessage::class, $result );
@@ -251,48 +263,47 @@ class Ability_Function_Resolver_Test extends Test_Case {
 	}
 
 	/**
-	 * Tests execute_abilities returns UserMessage.
+	 * Tests execute_abilities returns UserMessage via instance.
 	 *
 	 * @return void
 	 */
 	public function test_execute_abilities_returns_user_message(): void {
-		// WordPress 6.9 triggers an incorrect usage notice when ability is not found.
 		$this->setExpectedIncorrectUsage( 'WP_Abilities_Registry::get_registered' );
 
-		$call    = new FunctionCall( 'func_1', 'wpab__test__ability', array() );
-		$parts   = array( new MessagePart( $call ) );
-		$message = new ModelMessage( $parts );
+		$resolver = new Ability_Function_Resolver( 'test/ability' );
+		$call     = new FunctionCall( 'func_1', 'wpab__test__ability', array() );
+		$parts    = array( new MessagePart( $call ) );
+		$message  = new ModelMessage( $parts );
 
-		$result = Ability_Function_Resolver::execute_abilities( $message );
+		$result = $resolver->execute_abilities( $message );
 
 		$this->assertInstanceOf( UserMessage::class, $result );
 	}
 
 	/**
-	 * Tests execute_abilities processes multiple function calls.
+	 * Tests execute_abilities processes multiple function calls via instance.
 	 *
 	 * @return void
 	 */
 	public function test_execute_abilities_processes_multiple_calls(): void {
-		// WordPress 6.9 triggers incorrect usage notices for each ability not found.
 		$this->setExpectedIncorrectUsage( 'WP_Abilities_Registry::get_registered' );
 
-		$call1   = new FunctionCall( 'func_1', 'wpab__test__one', array() );
-		$call2   = new FunctionCall( 'func_2', 'wpab__test__two', array() );
-		$parts   = array(
+		$resolver = new Ability_Function_Resolver( 'test/one', 'test/two' );
+		$call1    = new FunctionCall( 'func_1', 'wpab__test__one', array() );
+		$call2    = new FunctionCall( 'func_2', 'wpab__test__two', array() );
+		$parts    = array(
 			new MessagePart( $call1 ),
 			new MessagePart( $call2 ),
 		);
-		$message = new ModelMessage( $parts );
+		$message  = new ModelMessage( $parts );
 
-		$result = Ability_Function_Resolver::execute_abilities( $message );
+		$result = $resolver->execute_abilities( $message );
 
 		$this->assertInstanceOf( Message::class, $result );
 
 		$result_parts = $result->getParts();
 		$this->assertCount( 2, $result_parts );
 
-		// Both should be FunctionResponse objects (with errors since abilities aren't registered).
 		$response1 = $result_parts[0]->getFunctionResponse();
 		$this->assertInstanceOf( FunctionResponse::class, $response1 );
 		$this->assertEquals( 'func_1', $response1->getId() );
@@ -303,25 +314,24 @@ class Ability_Function_Resolver_Test extends Test_Case {
 	}
 
 	/**
-	 * Tests execute_abilities only processes function call parts.
+	 * Tests execute_abilities only processes function call parts via instance.
 	 *
 	 * @return void
 	 */
 	public function test_execute_abilities_only_processes_function_calls(): void {
-		// WordPress 6.9 triggers an incorrect usage notice when ability is not found.
 		$this->setExpectedIncorrectUsage( 'WP_Abilities_Registry::get_registered' );
 
-		$call    = new FunctionCall( 'func_1', 'wpab__test__ability', array() );
-		$parts   = array(
+		$resolver = new Ability_Function_Resolver( 'test/ability' );
+		$call     = new FunctionCall( 'func_1', 'wpab__test__ability', array() );
+		$parts    = array(
 			new MessagePart( 'Text before' ),
 			new MessagePart( $call ),
 			new MessagePart( 'Text after' ),
 		);
-		$message = new ModelMessage( $parts );
+		$message  = new ModelMessage( $parts );
 
-		$result = Ability_Function_Resolver::execute_abilities( $message );
+		$result = $resolver->execute_abilities( $message );
 
-		// Only function calls are processed, not text parts.
 		$result_parts = $result->getParts();
 		$this->assertCount( 1, $result_parts );
 		$this->assertInstanceOf( FunctionResponse::class, $result_parts[0]->getFunctionResponse() );
@@ -348,13 +358,14 @@ class Ability_Function_Resolver_Test extends Test_Case {
 	}
 
 	/**
-	 * Tests execute_ability successfully executes a registered ability.
+	 * Tests execute_ability successfully executes a registered ability via instance.
 	 *
 	 * @return void
 	 */
 	public function test_execute_ability_success(): void {
+		$resolver = new Ability_Function_Resolver( 'wpaiclienttests/simple' );
 		$call     = new FunctionCall( 'func_123', 'wpab__wpaiclienttests__simple', array() );
-		$response = Ability_Function_Resolver::execute_ability( $call );
+		$response = $resolver->execute_ability( $call );
 
 		$this->assertInstanceOf( FunctionResponse::class, $response );
 		$this->assertEquals( 'func_123', $response->getId() );
@@ -367,13 +378,14 @@ class Ability_Function_Resolver_Test extends Test_Case {
 	}
 
 	/**
-	 * Tests execute_ability passes parameters to ability.
+	 * Tests execute_ability passes parameters to ability via instance.
 	 *
 	 * @return void
 	 */
 	public function test_execute_ability_with_parameters(): void {
+		$resolver = new Ability_Function_Resolver( 'wpaiclienttests/with-params' );
 		$call     = new FunctionCall( 'func_456', 'wpab__wpaiclienttests__with-params', array( 'title' => 'Test Title' ) );
-		$response = Ability_Function_Resolver::execute_ability( $call );
+		$response = $resolver->execute_ability( $call );
 
 		$this->assertInstanceOf( FunctionResponse::class, $response );
 
@@ -386,13 +398,14 @@ class Ability_Function_Resolver_Test extends Test_Case {
 	}
 
 	/**
-	 * Tests execute_ability handles WP_Error from ability.
+	 * Tests execute_ability handles WP_Error from ability via instance.
 	 *
 	 * @return void
 	 */
 	public function test_execute_ability_handles_wp_error(): void {
+		$resolver = new Ability_Function_Resolver( 'wpaiclienttests/returns-error' );
 		$call     = new FunctionCall( 'func_789', 'wpab__wpaiclienttests__returns-error', array() );
-		$response = Ability_Function_Resolver::execute_ability( $call );
+		$response = $resolver->execute_ability( $call );
 
 		$this->assertInstanceOf( FunctionResponse::class, $response );
 		$this->assertEquals( 'func_789', $response->getId() );
@@ -406,16 +419,17 @@ class Ability_Function_Resolver_Test extends Test_Case {
 	}
 
 	/**
-	 * Tests execute_abilities successfully executes registered abilities.
+	 * Tests execute_abilities successfully executes registered abilities via instance.
 	 *
 	 * @return void
 	 */
 	public function test_execute_abilities_success(): void {
-		$call    = new FunctionCall( 'func_1', 'wpab__wpaiclienttests__simple', array() );
-		$parts   = array( new MessagePart( $call ) );
-		$message = new ModelMessage( $parts );
+		$resolver = new Ability_Function_Resolver( 'wpaiclienttests/simple' );
+		$call     = new FunctionCall( 'func_1', 'wpab__wpaiclienttests__simple', array() );
+		$parts    = array( new MessagePart( $call ) );
+		$message  = new ModelMessage( $parts );
 
-		$result = Ability_Function_Resolver::execute_abilities( $message );
+		$result = $resolver->execute_abilities( $message );
 
 		$this->assertInstanceOf( UserMessage::class, $result );
 
@@ -431,37 +445,134 @@ class Ability_Function_Resolver_Test extends Test_Case {
 	}
 
 	/**
-	 * Tests execute_abilities with multiple registered abilities.
+	 * Tests execute_abilities with multiple registered abilities via instance.
 	 *
 	 * @return void
 	 */
 	public function test_execute_abilities_multiple_success(): void {
-		$call1   = new FunctionCall( 'func_1', 'wpab__wpaiclienttests__simple', array() );
-		$call2   = new FunctionCall( 'func_2', 'wpab__wpaiclienttests__with-params', array( 'title' => 'Test' ) );
-		$parts   = array(
+		$resolver = new Ability_Function_Resolver( 'wpaiclienttests/simple', 'wpaiclienttests/with-params' );
+		$call1    = new FunctionCall( 'func_1', 'wpab__wpaiclienttests__simple', array() );
+		$call2    = new FunctionCall( 'func_2', 'wpab__wpaiclienttests__with-params', array( 'title' => 'Test' ) );
+		$parts    = array(
 			new MessagePart( $call1 ),
 			new MessagePart( $call2 ),
 		);
-		$message = new ModelMessage( $parts );
+		$message  = new ModelMessage( $parts );
 
-		$result = Ability_Function_Resolver::execute_abilities( $message );
+		$result = $resolver->execute_abilities( $message );
 
 		$result_parts = $result->getParts();
 		$this->assertCount( 2, $result_parts );
 
-		// First ability response.
 		$response1 = $result_parts[0]->getFunctionResponse();
 		$this->assertInstanceOf( FunctionResponse::class, $response1 );
 		$this->assertEquals( 'func_1', $response1->getId() );
 		$response1_data = $response1->getResponse();
 		$this->assertTrue( $response1_data['success'] );
 
-		// Second ability response.
 		$response2 = $result_parts[1]->getFunctionResponse();
 		$this->assertInstanceOf( FunctionResponse::class, $response2 );
 		$this->assertEquals( 'func_2', $response2->getId() );
 		$response2_data = $response2->getResponse();
 		$this->assertTrue( $response2_data['success'] );
 		$this->assertEquals( 'Test', $response2_data['title'] );
+	}
+
+	/**
+	 * Tests execute_ability rejects ability not in allowed list.
+	 *
+	 * @return void
+	 */
+	public function test_execute_ability_rejects_ability_not_in_allowed_list(): void {
+		$resolver = new Ability_Function_Resolver( 'wpaiclienttests/simple' );
+		$call     = new FunctionCall( 'func_1', 'wpab__wpaiclienttests__with-params', array( 'title' => 'Test' ) );
+		$response = $resolver->execute_ability( $call );
+
+		$this->assertInstanceOf( FunctionResponse::class, $response );
+
+		$result = $response->getResponse();
+		$this->assertIsArray( $result );
+		$this->assertArrayHasKey( 'error', $result );
+		$this->assertStringContainsString( 'not specified in the allowed abilities list', $result['error'] );
+		$this->assertEquals( 'ability_not_allowed', $result['code'] );
+	}
+
+	/**
+	 * Tests execute_ability rejects all abilities when constructed with no abilities.
+	 *
+	 * @return void
+	 */
+	public function test_execute_ability_rejects_all_when_no_abilities_specified(): void {
+		$resolver = new Ability_Function_Resolver();
+		$call     = new FunctionCall( 'func_1', 'wpab__wpaiclienttests__simple', array() );
+		$response = $resolver->execute_ability( $call );
+
+		$this->assertInstanceOf( FunctionResponse::class, $response );
+
+		$result = $response->getResponse();
+		$this->assertIsArray( $result );
+		$this->assertEquals( 'ability_not_allowed', $result['code'] );
+	}
+
+	/**
+	 * Tests execute_abilities filters by allowed list.
+	 *
+	 * @return void
+	 */
+	public function test_execute_abilities_filters_by_allowed_list(): void {
+		$resolver = new Ability_Function_Resolver( 'wpaiclienttests/simple' );
+		$call1    = new FunctionCall( 'func_1', 'wpab__wpaiclienttests__simple', array() );
+		$call2    = new FunctionCall( 'func_2', 'wpab__wpaiclienttests__with-params', array( 'title' => 'Test' ) );
+		$parts    = array(
+			new MessagePart( $call1 ),
+			new MessagePart( $call2 ),
+		);
+		$message  = new ModelMessage( $parts );
+
+		$result = $resolver->execute_abilities( $message );
+
+		$result_parts = $result->getParts();
+		$this->assertCount( 2, $result_parts );
+
+		$response1_data = $result_parts[0]->getFunctionResponse()->getResponse();
+		$this->assertArrayHasKey( 'success', $response1_data );
+		$this->assertTrue( $response1_data['success'] );
+
+		$response2_data = $result_parts[1]->getFunctionResponse()->getResponse();
+		$this->assertEquals( 'ability_not_allowed', $response2_data['code'] );
+	}
+
+	/**
+	 * Tests constructor accepts WP_Ability objects.
+	 *
+	 * @return void
+	 */
+	public function test_constructor_accepts_wp_ability_objects(): void {
+		$ability  = wp_get_ability( 'wpaiclienttests/simple' );
+		$resolver = new Ability_Function_Resolver( $ability );
+		$call     = new FunctionCall( 'func_1', 'wpab__wpaiclienttests__simple', array() );
+		$response = $resolver->execute_ability( $call );
+
+		$result = $response->getResponse();
+		$this->assertArrayHasKey( 'success', $result );
+		$this->assertTrue( $result['success'] );
+	}
+
+	/**
+	 * Tests constructor accepts mixed WP_Ability objects and strings.
+	 *
+	 * @return void
+	 */
+	public function test_constructor_accepts_mixed_ability_types(): void {
+		$ability  = wp_get_ability( 'wpaiclienttests/simple' );
+		$resolver = new Ability_Function_Resolver( $ability, 'wpaiclienttests/with-params' );
+
+		$call1     = new FunctionCall( 'func_1', 'wpab__wpaiclienttests__simple', array() );
+		$response1 = $resolver->execute_ability( $call1 );
+		$this->assertArrayHasKey( 'success', $response1->getResponse() );
+
+		$call2     = new FunctionCall( 'func_2', 'wpab__wpaiclienttests__with-params', array( 'title' => 'Test' ) );
+		$response2 = $resolver->execute_ability( $call2 );
+		$this->assertArrayHasKey( 'success', $response2->getResponse() );
 	}
 }


### PR DESCRIPTION
This addresses a security weakness: At no point so far we were checking (or at least encouraging) that the abilities called in a message are actually among the abilities allowed for the prompt.

Not checking this can lead to security vulnerabilities, e.g. through prompt injection.

While developers today could work around this by manually checking prior to using `Ability_Function_Resolver`, this is not intuitive at all. Since it's a security concern, it needs to be baked in and mandatory.

**This is a breaking change.** The `Ability_Function_Resolver` class becomes (mostly) non-static, and will require an instance for usage going forward. It will require passing the list of abilities in the constructor, in the same shape it's used on `Prompt_Builder::using_abilities()`.